### PR TITLE
Format 4 cmap are incorrects and are rejected by browser's font sanitizer

### DIFF
--- a/lib/font/tables/cmap.coffee
+++ b/lib/font/tables/cmap.coffee
@@ -134,8 +134,8 @@ class CmapEntry
                 
                 segCount = startCodes.length
                 segCountX2 = segCount * 2
-                searchRange = 2 * Math.pow(Math.log(segCount) / Math.LN2, 2)
-                entrySelector = Math.log(searchRange / 2) / Math.LN2
+                searchRange = 2 * Math.pow(2, Math.floor(Math.log(segCount) / Math.LN2))
+                entrySelector = Math.log(segCount) / Math.LN2
                 rangeShift = 2 * segCount - searchRange
                 
                 deltas = []
@@ -146,7 +146,7 @@ class CmapEntry
                     endCode = endCodes[i]
                     
                     if startCode is 0xFFFF
-                        deltas.push 0
+                        deltas.push 1
                         rangeOffsets.push 0
                         break
                         


### PR DESCRIPTION
With this the format 4 cmap is correct and the font sanitizer is happy.

This patch partially fix https://github.com/andreasgal/pdf.js/issues/560, the embedded font is used but they looks weird (that's something on the side of pdf.js). 
