### PR TITLE
Allow changing styles within wrapped text

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -190,8 +190,8 @@ module.exports =
           wrap.continuedX = 0         # offset from @x leftover from the previous _wrap call
           wrap.continuedY = 0         # @y of the last line of the previous _wrap call
 
-        # calculate the maximum Y position the text can appear at
-        wrap.maxY = @y + options.height - @currentLineHeight()
+          # calculate the maximum Y position the text can appear at
+          wrap.maxY = @y + options.height - @currentLineHeight()
         
         # split the line into words
         words = text.match(WORD_RE)


### PR DESCRIPTION
This adds a new option named `continued` to `text`. If you set it to true, the wrapping state will be left in place so the next call to `text` will pick up where it left off.

Using this you can switch styles like `fillColor` and `font` and then continue outputting text within the same flow.

[Here is a demo of the feature](http://ef4.github.com/pdfkit-www/continued.html) (running in-browser with pdfkit-www, doesn't work on IE).
