### PR TITLE
Allow user to locate wrapped text lines

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -131,7 +131,7 @@ module.exports =
         
         # user-accessible hook
         if options.eachLine
-          options.eachLine(text, x, y)
+          options.eachLine.apply(this, [text, x, y])
 
         # flip coordinate system
         y = @page.height - y - (@_font.ascender / 1000 * @_fontSize)


### PR DESCRIPTION
This little changes adds an 'eachLine' option to 'text'. You can set
it to a callback that will be called with the arguments (text, x, y)
for each line of text that gets generated.

This makes it possible to figure out eactly where the text has been
placed in order to add annotations to it, or add other graphics that
need to be placed relative to the text.
