### PR TITLE
Fixes issue #40: Overzealous word splitting

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -1,5 +1,5 @@
 # This regular expression is used for splitting a string into wrappable words
-WORD_RE = /([^ \t\r]+[ \t\r]*)|\n/g
+WORD_RE = /([^ \t\r\n]+[ \t\r]*)|\n/g
 
 module.exports = 
     initText: ->


### PR DESCRIPTION
pdfkit breaks lines at the punctuation within words like "A.B.C" or "3.14159" or "1,000". 

This change causes it to split only where non-whitespace runs up against whitespace.
