### PR TITLE
Fix for Acrobat Reader crash on undash

### DIFF
--- a/lib/mixins/vector.coffee
+++ b/lib/mixins/vector.coffee
@@ -46,7 +46,7 @@ module.exports =
         @addContent "[#{length} #{space}] #{phase} d"
         
     undash: ->
-        @addContent "[null null] 0 d"
+        @addContent "[] 0 d"
         
     moveTo: (x, y) ->
         y = @page.height - y


### PR DESCRIPTION
Undash should use [] 0 d instead of [null null] 0 d.
