### PR TITLE
Allow setting dash spacing to 0

### DIFF
--- a/lib/mixins/vector.coffee
+++ b/lib/mixins/vector.coffee
@@ -40,7 +40,7 @@ module.exports =
     dash: (length, options = {}) ->
         return this unless length?
         
-        space = options.space or length
+        space = if options.space? then options.space else length
         phase = options.phase or 0
         
         @addContent "[#{length} #{space}] #{phase} d"


### PR DESCRIPTION
Currently, calling dash(5,{space:0}) will result in dash(5,{space:5}) because default arguments are assigned using 'or' with the undesired consequence of 0 being impossible to set as space.  This patch fixes dash to behave more as expected.
