### PR TITLE
Nested lists

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -75,9 +75,12 @@ module.exports =
         @y = y = oy or @y
 
         for item in array
-            @circle x + 3, @y + gap + 3, 3
-            @text item, x + 15
-            @y += 3
+            if item instanceof Array
+                @list item, x + 15
+            else
+                @circle x + 3, @y + gap + 3, 3
+                @text item, x + 15
+                @y += 3
 
         @x = x
         @fill()


### PR DESCRIPTION
This adds basic support for nested lists. Usage:

``` coffeescript
doc.list(['One', ['Two', ['foo', 'bar'], 'Three'], 'four'])
```

Relevant patch starts here: https://github.com/booo/pdfkit/pull/new/nested_lists#L0R78

Best Regards
Philipp
