### PR TITLE
Fixed path parsing bug

### DIFF
--- a/lib/path.coffee
+++ b/lib/path.coffee
@@ -45,7 +45,7 @@ class SVGPath
 
                 cmd = c
 
-            else if c in [" ", ","] or (c is "-" and curArg.length > 0) or (c is "." and foundDecimal)
+            else if c in [" ", ","] or (c is "-" and curArg.length > 0 and curArg[curArg.length-1]!='e') or (c is "." and foundDecimal)
                 continue if curArg.length is 0
 
                 if args.length is params # handle reused commands


### PR DESCRIPTION
The path parser doesn't handle numbers like `1e-4` correctly because it always treats `-` as the start of a new parameter.

(I don't know what the SVG standard says about formatting numbers this way, but Inkscape definitely will output them like that.)
