### PR TITLE
Fix bug in Line_Wrapper ignoring \n in most cases.  (Causes text wrapping to be wrong)

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -64,7 +64,7 @@ class LineWrapper extends EventEmitter
             for word, wi in words
                 w = wordWidths[word] ?= width(word, options) + charSpacing + wordSpacing
 
-                if w > spaceLeft
+                if w > spaceLeft or word is '\n'
                     options.textWidth = width(buffer.trim(), options) + wordSpacing * (wc - 1)
                     @emit 'line', buffer.trim(), options, this
                                         


### PR DESCRIPTION
If the Line_Wrapper is called with a String "Hello\nMr. Anderson," then the Line_Wrapper will calculate it as "Hello Mr. Anderson".  (i.e. Treat it as One single Line -- assuming the width is great enough) 
But it will actually write it to the PDF as 
"Hello
Mr. Anderson".   So we need to the \n in the stream we can force a new line and emit it.
