### PR TITLE
Have output return a binary buffer

### DIFF
--- a/lib/document.coffee
+++ b/lib/document.coffee
@@ -98,11 +98,11 @@ class PDFDocument
                @generateXRef out
                @generateTrailer out
                
-               ret = ''
+               ret = []
                for k in out
-                   ret += k + '\n'
+                   ret.push(k + '\n')
                    
-               fn ret
+               fn new Buffer(ret.join(''),'binary')
         
     finalize: (fn) ->
         # convert strings in the info dictionary to literals


### PR DESCRIPTION
Right now output returns a string to its callback, this means you can't just write it to a file or send it to a response as the default encoding (utf8) is incorrect. You have to manually specify binary. If instead of a string you return a binary buffer then you don't have to worry about this.

I also fixed the generation of the final string to not build the string with repeated concatenation which is O(n^2) and instead build up an array of strings then join them all at once which is O(n)
