### PR TITLE
Fixes the eating of prefix characters:

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -1,5 +1,5 @@
 # This regular expression is used for splitting a string into wrappable words
-WORD_RE = /([^ ,\/!.?:;\-\n]+[ ,\/!.?:;\-]*)|\n/g
+WORD_RE = /([^ ,\/!.?:;\-\n]*[ ,\/!.?:;\-]*)|\n/g
 {EventEmitter} = require 'events'
 
 class LineWrapper extends EventEmitter

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -1,4 +1,4 @@
-WORD_RE = /([^ ,\/!.?:;\-\n]+[ ,\/!.?:;\-]*)|\n/g
+WORD_RE = /([^ ,\/!.?:;\-\n]*[ ,\/!.?:;\-]*)|\n/g
 LineWrapper = require '../line_wrapper'
 
 module.exports = 


### PR DESCRIPTION
This fixes the issues when you send text like so:

": 30" -> "30"
"-30" -> "30"
".30" -> "30"

The replacement regex will allow all those characters as prefix characters also.  
