### PR TITLE
Fix setting text x or y to 0

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -114,9 +114,10 @@ module.exports =
             return opts
 
         # Update the current position
-        if x? or y?
-            @x = x or @x
-            @y = y or @y
+        if x?
+            @x = x
+        if y?
+            @y = y
 
         # wrap to margins if no x or y position passed
         unless options.lineBreak is false


### PR DESCRIPTION
Because of the use of the construction "@x = x or @x" there was no way
to set x (or y) to 0, since 0 is falsy.  Fix to use separate outer tests
and unconditional assignment.
