### PR TITLE
Fixes the invalid calculation of page size in Line Wrapper.

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -33,7 +33,7 @@ class LineWrapper extends EventEmitter
         @column = 1
         
         # calculate the maximum Y position the text can appear at
-        @maxY = @startY + options.height - @document.currentLineHeight()
+        @maxY = @startY + options.height
         
         # make sure we're actually on the page 
         # and that the first line of is never by 


### PR DESCRIPTION
The line Wrapper improperly calculates the maxY in the line calculation.  

@startY + options.height will actually = the full remainder of the page, by the prior code subtracting out the height of a line of text,  it just wrapped a the last line of text too early as the last line of text could never fit.
