### PR TITLE
Character width sizes are wrong if the font cmap table is incomplete

### DIFF
--- a/lib/font.coffee
+++ b/lib/font.coffee
@@ -196,7 +196,7 @@ class PDFFont
         width = 0
         for i in [0...string.length]
             charCode = string.charCodeAt(i) - if @isAFM then 0 else 32
-            width += @charWidths[charCode] or 0
+            width += @charWidths[charCode] or @charWidths[if @isAFM then 48 else 16] or 0
         
         scale = size / 1000    
         return width * scale


### PR DESCRIPTION
This "hack" will use "0" as the character if the real character is not present in the table; as "0" is reasonably likely to exist if it also doesn't exist it will fall back to the old code of returning 0.

This should for the most part fix: https://github.com/devongovett/pdfkit/issues/169 as it is caused by the same issue of fonts not having full cmap tables.   
