### PR TITLE
Support for latin1-special characters and euro-sign with standard fonts

### DIFF
--- a/lib/font.coffee
+++ b/lib/font.coffee
@@ -34,45 +34,49 @@ class PDFFont
         @embedTTF fn
         
     _WinAnsiMap: {
-        402: 131,
-        8211: 150,
-        8212: 151,
-        8216: 145,
-        8217: 146,
-        8218: 130,
-        8220: 147,
-        8221: 148,
-        8222: 132,
-        8224: 134,
-        8225: 135,
-        8226: 149,
-        8230: 133,
-        8364: 128,
-        8240:137,
-        8249: 139,
-        8250: 155,
-        710: 136,
-        8482: 153,
-        338: 140,
-        339: 156,
-        732: 152,
-        352: 138,
-        353: 154,
-        376: 159,
-        381: 142,
+        402: 131
+        8211: 150
+        8212: 151
+        8216: 145
+        8217: 146
+        8218: 130
+        8220: 147
+        8221: 148
+        8222: 132
+        8224: 134
+        8225: 135
+        8226: 149
+        8230: 133
+        8364: 128
+        8240: 137
+        8249: 139
+        8250: 155
+        710: 136
+        8482: 153
+        338: 140
+        339: 156
+        732: 152
+        352: 138
+        353: 154
+        376: 159
+        381: 142
         382: 158
     }
 
     _encodeWinAnsi: (text) ->
         string = ''
         for i in [0...text.length]
-            char = @_WinAnsiMap[text.charCodeAt(i)] || text.charCodeAt(i)
+            char = text.charCodeAt(i)
+            char = @_WinAnsiMap[char] || char
             string += String.fromCharCode(char)
         
         return string
 
     encode: (text) ->
-        @subset?.encodeText(text) or text
+        if @isAFM
+            @_encodeWinAnsi text
+        else
+            @subset?.encodeText(text) or text
         
     registerTTF: ->
         @scaleFactor = 1000.0 / @ttf.head.unitsPerEm
@@ -212,7 +216,6 @@ class PDFFont
             BaseFont: @filename
             Subtype: 'Type1'
             Encoding: 'WinAnsiEncoding'
-        @encode = @_encodeWinAnsi
             
     _standardFonts: [
         "Courier"


### PR DESCRIPTION
When using a PDF standard font, the encoding is set to WinAnsiEncoding.
In addition, a encoding function is used to translate from UTF-8 to WinAnsiEncoding (table taken from jsPDF).

This gives access to e.g. the EUR-sign and to some of the latin1-based special characters (e.g. German umlaute).

It also addresses issue #137.
