### PR TITLE
Fixed a bug where the xref table would have incorrect offsets.

### DIFF
--- a/lib/document.coffee
+++ b/lib/document.coffee
@@ -129,7 +129,7 @@ class PDFDocument
         return out
         
     generateBody: (out, fn) ->
-        offset = out.join('\n').length
+        offset = out.join('\n').length + 1
         
         refs = (ref for id, ref of @store.objects)
         do proceed = =>
@@ -155,7 +155,7 @@ class PDFDocument
             
     generateTrailer: (out) ->
         trailer = PDFObject.convert
-            Size: @store.length
+            Size: @store.length + 1
             Root: @store.root
             Info: @_info
 


### PR DESCRIPTION
The additional "\n" character upon the final ".join" of data wasn't taken into account. This may fix #173 and #147.
