### PR TITLE
fix a few max call stack size exceeded errors

### DIFF
--- a/lib/image/jpeg.coffee
+++ b/lib/image/jpeg.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 Data = '../data'
+setImmediate = setImmediate ? process.nextTick # backfill for node <0.10
 
 class JPEG
     constructor: (@data) ->
@@ -49,6 +50,6 @@ class JPEG
             obj.data['Decode'] = [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
             
         obj.add @data.data
-        fn obj
+        setImmediate -> fn(obj)
         
 module.exports = JPEG

--- a/lib/image/png.coffee
+++ b/lib/image/png.coffee
@@ -1,5 +1,6 @@
 zlib = require 'zlib'
 PNG = require 'png-js'
+setImmediate = setImmediate ? process.nextTick # backfill for node <0.10
 
 class PNGImage
     constructor: (data) ->
@@ -87,7 +88,7 @@ class PNGImage
 
         # add the actual image data    
         obj.add @imgData
-        fn obj
+        setImmediate -> fn(obj)
         
     splitAlphaChannel: (fn) ->
         @image.decodePixels (pixels) =>

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -4,6 +4,7 @@ By Devon Govett
 ###
 
 zlib = require 'zlib'
+setImmediate = setImmediate ? process.nextTick # backfill for node <0.10
 
 class PDFReference
     constructor: (@id, @data = {}) ->
@@ -47,10 +48,10 @@ class PDFReference
             else
                 @finalizedStream = data
                 @data.Length = @finalizedStream.length
-                fn()
+                setImmediate fn
         else
             @finalizedStream = ''
-            fn()
+            setImmediate fn
         
     toString: ->
         "#{@id} #{@gen} R"


### PR DESCRIPTION
Resolves a RangeError when finalizing documents with many images and/or many pages.  Basically we're just ensuring that async functions call the callback in the next event loop in a few places where sometimes they returned async but sometimes they returned sync.

should resolve https://github.com/devongovett/pdfkit/issues/110
