### PR TITLE
Correcting for edge case in line wrapping

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -165,7 +165,12 @@ class LineWrapper extends EventEmitter
                         return no
                 
                 # reset the space left and buffer
-                if bk.required and w <= @spaceLeft
+                if bk.required
+                    # if there's a word but no space left, emit single line
+                    if w > @spaceLeft
+                        buffer = word
+                        textWidth = w
+                        emitLine()
                     @spaceLeft = @lineWidth
                     buffer = ''
                     textWidth = 0


### PR DESCRIPTION
If you look at the flow of the `eachWord` function, you'll notice that we add the word to the buffer if the width of the word `w` is less than the space available.

There's an edge case involving manual line breaks, where `linebreaker` says that a line break is required on a word (because of the manual break, for example: `theword\n` ) yet the width of the word being considered is greater than `spaceLeft`. In the current pdfkit, if this is the case:
- we do not append the word to the buffer (correctly, because there is not enough space)
- we emit the buffer as-is (also correct)
- we break and move on to the next line, starting with a clean line (incorrect as now our final word is missing)

This omits the word entirely.

This commit makes it so that we only break the line and start with a clean line if we already had the space to write the line to the buffer. Otherwise, we append the word to the buffer and go to a new line.
