### PR TITLE
Fix dependencies for browser-demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "browserify": "^3.39.0",
     "brfs": "~1.0.1",
     "exorcist": "^0.1.5",
-    "brace": "^0.2.1"
+    "brace": "^0.2.1",
+    "blob-stream": "^0.1.2"
   },
   "dependencies": {
     "png-js": ">=0.1.0",
-    "linebreak": "~0.1.0",
-    "blob-stream": "^0.1.2"
+    "linebreak": "~0.1.0"
   },
   "scripts": {
     "prepublish": "make js",


### PR DESCRIPTION
Restrict brfs' version to fix unexpected identifier errors. See #230.
Add blob-stream as a dependency.

---

This fixes a couple minor issues I ran into regarding the dependencies for the browser-demo.
