### PR TITLE
Add ability to add base64 URI images

### DIFF
--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -13,9 +13,8 @@ class PDFImage
     if Buffer.isBuffer(src)
       data = src
     else
-      if src[0..4] is 'data:' and src.indexOf(';base64,') > -1
-        base64String = src.split(';base64,')[1]
-        data = new Buffer(base64String, 'base64')
+      if match = /^data:.+;base64,(.*)$/.exec(src)
+        data = new Buffer(match[1], 'base64')
 
       else
         data = fs.readFileSync src


### PR DESCRIPTION
From what I could tell, there didn't appear to be a direct way to add an image when using PDFKit from a browser. This adds the ability to feed a base64 encoded data URI to `doc.image`. I wasn't sure what the best way (or your preferred way) is to detect if we're dealing with a base64 data URI so I went with what's currently in there.

Example:

``` javascript
// red_dot URI from https://en.wikipedia.org/wiki/Data_URI_scheme
var red_dot = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';
doc.image(red_dot, 50, 50, {
    width: 10
});
```
