### PR TITLE
Improve sizing of text underline

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -207,7 +207,7 @@ module.exports =
       @save()
       @strokeColor @_fillColor... unless options.stroke
       
-      lineWidth = if @_fontSize >= 20 then 2 else 1
+      lineWidth = if @_fontSize < 10 then 0.5 else Math.floor(@_fontSize / 10)
       @lineWidth lineWidth
       
       d = if options.underline then 1 else 2


### PR DESCRIPTION
I noticed that the underline sizing for font sizes at or below 10 seemed a bit strong. This attempts to balance it out by allowing it to scale with the font size beyond the 10 and 20 thresholds.

![underline size comparison](https://cloud.githubusercontent.com/assets/604125/2924548/980f213e-d737-11e3-8998-0a8f7ab5907a.png)
