### PR TITLE
Fix indent with continued

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -34,6 +34,8 @@ class LineWrapper extends EventEmitter
       @once 'line', =>
         @document.x -= indent
         @lineWidth += indent
+        if options.continued and not @continuedX
+          @continuedX = @indent
         @continuedX = 0 unless options.continued
     
     # handle left aligning last lines of paragraphs


### PR DESCRIPTION
`continued: true` and `indent` don't work correctly together. This change fixes the problem by properly shifting the continued text over by the indent amount. 

Here is a sample program that demonstrates the problem and fix:

``` javascript
var fs = require('fs');
var PDFDocument = require('pdfkit');
var doc = new PDFDocument();
var stream = doc.pipe(fs.createWriteStream('./out.pdf'));

var lorem = "Bacon ipsum dolor sit amet shankle spare ribs boudin kevin beef ribs cow short loin t-bone filet mignon swine. Pork chop strip steak pork loin tri-tip leberkas short ribs beef ribs rump sausage pork salami. Pastrami rump short ribs biltong tri-tip salami sirloin short loin cow brisket tail chicken shank meatloaf tenderloin. Tenderloin andouille jerky shoulder landjaeger tri-tip flank swine boudin shank. Salami short ribs pig sausage tail short loin jerky.";

doc.fillColor('#ff0000');
doc.text(lorem.slice(0, 10), {indent: 16, continued: true});
doc.fillColor('#000000');
doc.text(lorem.slice(10));
doc.end();

stream.on('finish', function() {
  process.exit(0);
});
```
