### PR TITLE
Fix center-aligned character spacing

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -4,7 +4,7 @@ LineBreaker = require 'linebreak'
 class LineWrapper extends EventEmitter
   constructor: (@document, options) ->
     @indent    = options.indent or 0
-    @charSpacing = options.characterSpacing or 0
+    @characterSpacing = options.characterSpacing or 0
     @wordSpacing = options.wordSpacing is 0
     @columns   = options.columns or 1
     @columnGap   = options.columnGap ? 18 # 1/4 inch
@@ -48,7 +48,7 @@ class LineWrapper extends EventEmitter
         @lastLine = false
         
   wordWidth: (word) ->
-    return @document.widthOfString(word, this) + @charSpacing + @wordSpacing
+    return @document.widthOfString(word, this) + @characterSpacing + @wordSpacing
         
   eachWord: (text, fn) ->
     # setup a unicode line breaker
@@ -95,7 +95,7 @@ class LineWrapper extends EventEmitter
   wrap: (text, options) ->
     # override options from previous continued fragments
     @indent    = options.indent       if options.indent?
-    @charSpacing = options.characterSpacing if options.characterSpacing?
+    @characterSpacing = options.characterSpacing if options.characterSpacing?
     @wordSpacing = options.wordSpacing    if options.wordSpacing?
     @ellipsis  = options.ellipsis     if options.ellipsis?
     


### PR DESCRIPTION
Center-aligned text fails to take into account the character spacing. The fix just requires renaming `@charSpacing` so that the `widthOfString` function in `mixins/text` will see it.

Here is a minimal sample document that demonstrates the issue:

``` javascript
var fs = require('fs');
var PDFDocument = require('pdfkit');
var doc = new PDFDocument();
var stream = doc.pipe(fs.createWriteStream('./out.pdf'));

function test(charSpacing) {
  doc.rect(150, doc.y, 150, 30).stroke('#000');
  doc.x = 150;
  doc.y += 10;
  doc.text("Testing", {width: 150, align: 'center', characterSpacing: charSpacing});
  doc.moveDown();
}

test();
test(3);
doc.end();

stream.on('finish', function() {
  process.exit(0);
});
```
