### PR TITLE
Prevent missing ascender from breaking layout

### DIFF
--- a/lib/font/afm.coffee
+++ b/lib/font/afm.coffee
@@ -13,8 +13,8 @@ class AFMFont
     @charWidths = (@glyphWidths[characters[i]] for i in [0..255])
     
     @bbox = (+e for e in @attributes['FontBBox'].split /\s+/)
-    @ascender = +@attributes['Ascender']
-    @decender = +@attributes['Descender']
+    @ascender = +(@attributes['Ascender'] or 0)
+    @decender = +(@attributes['Descender'] or 0)
     @lineGap = (@bbox[3] - @bbox[1]) - (@ascender - @decender)
   
   parse: ->


### PR DESCRIPTION
ZapfDingbats (and perhaps others) has no ascender or descender attributes. pdfkit is treating them as `NaN`, which causes `document.y` to also ends up as `NaN` if you try to render any text in this font.
