### PR TITLE
TTFFont.parse should call *Table constructors with explicit @tag param

### DIFF
--- a/lib/font/table.coffee
+++ b/lib/font/table.coffee
@@ -1,5 +1,5 @@
 class Table
-  constructor: (@file, @tag) ->
+  constructor: (@file) ->
     info = @file.directory.tables[@tag]
     @exists = !!info
     

--- a/lib/font/tables/cmap.coffee
+++ b/lib/font/tables/cmap.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class CmapTable extends Table
+  constructor: ->
+    @tag = 'cmap'
+    super
+  
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/tables/glyf.coffee
+++ b/lib/font/tables/glyf.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class GlyfTable extends Table
+  constructor: ->
+    @tag = 'glyf'
+    super
+  
   parse: (data) ->
     # We're not going to parse the whole glyf table, just the glyfs we need.  See below.
     @cache = {}

--- a/lib/font/tables/head.coffee
+++ b/lib/font/tables/head.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class HeadTable extends Table
+  constructor: ->
+    @tag = 'head'
+    super
+  
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/tables/hhea.coffee
+++ b/lib/font/tables/hhea.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class HheaTable extends Table
+  constructor: ->
+    @tag = 'hhea'
+    super
+  
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/tables/hmtx.coffee
+++ b/lib/font/tables/hmtx.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class HmtxTable extends Table
+  constructor: ->
+    @tag = 'hmtx'
+    super
+
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/tables/loca.coffee
+++ b/lib/font/tables/loca.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class LocaTable extends Table
+  constructor: ->
+    @tag = 'loca'
+    super
+
   parse: (data) ->
     data.pos = @offset
     format = @file.head.indexToLocFormat

--- a/lib/font/tables/maxp.coffee
+++ b/lib/font/tables/maxp.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class MaxpTable extends Table
+  constructor: ->
+    @tag = 'maxp'
+    super
+    
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/tables/name.coffee
+++ b/lib/font/tables/name.coffee
@@ -3,6 +3,10 @@ Data = require '../../data'
 utils = require '../utils'
 
 class NameTable extends Table
+  constructor: ->
+    @tag = 'name'
+    super
+
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/tables/post.coffee
+++ b/lib/font/tables/post.coffee
@@ -2,6 +2,10 @@ Table = require '../table'
 Data = require '../../data'
 
 class PostTable extends Table
+  constructor: ->
+    @tag = 'post'
+    super
+
   parse: (data) ->
     data.pos = @offset
     

--- a/lib/font/ttf.coffee
+++ b/lib/font/ttf.coffee
@@ -68,16 +68,16 @@ class TTFFont
     
   parse: ->
     @directory = new Directory(@contents)
-    @head = new HeadTable(this, 'head')
-    @name = new NameTable(this, 'name')
-    @cmap = new CmapTable(this, 'cmap')
-    @hhea = new HheaTable(this, 'hhea')
-    @maxp = new MaxpTable(this, 'maxp')
-    @hmtx = new HmtxTable(this, 'hmtx')
-    @post = new PostTable(this, 'post')
-    @os2  = new OS2Table(this, 'os2')
-    @loca = new LocaTable(this, 'loca')
-    @glyf = new GlyfTable(this, 'glyf')
+    @head = new HeadTable(this)
+    @name = new NameTable(this)
+    @cmap = new CmapTable(this)
+    @hhea = new HheaTable(this)
+    @maxp = new MaxpTable(this)
+    @hmtx = new HmtxTable(this)
+    @post = new PostTable(this)
+    @os2  = new OS2Table(this)
+    @loca = new LocaTable(this)
+    @glyf = new GlyfTable(this)
     
     @ascender = (@os2.exists and @os2.ascender) or @hhea.ascender
     @decender = (@os2.exists and @os2.decender) or @hhea.decender


### PR DESCRIPTION
the bug appears when the library is bundled with browserify+uglify (or any other minify lib); by default uglify task mangle function names so in the `Table` constructor code like `@constructor.name` would return some `'b'`or `'c'`which leads to errors hard to debug (since the problem appears only with the minified versions;  like this one bpampuch/pdfmake#18 or this one bpampuch/pdfmake#60 )

Is it good or bad to rely on function names at runtime (especially if we are targeting the browser)?
See this interesting discussion visionmedia/jade#298 (`uglify` vs `jade`) 
