### PR TITLE
Avoid unnecessarily breaking inside words when using `continued`

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -64,7 +64,7 @@ class LineWrapper extends EventEmitter
       
       # if the word is longer than the whole line, chop it up
       # TODO: break by grapheme clusters, not JS string characters
-      if w > @lineWidth
+      if w > @lineWidth + @continuedX
         # make some fake break objects
         lbk = last
         fbk = {}


### PR DESCRIPTION
`continued` is implemented by temporarily shortening the `lineWidth`, which can cause the linewrapper to break inside words when that's not really necessary.
