### PR TITLE
Infinite loop when first word is longer than line

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -9,6 +9,7 @@ class LineWrapper extends EventEmitter
     @columns   = options.columns or 1
     @columnGap   = options.columnGap ? 18 # 1/4 inch
     @lineWidth   = (options.width - (@columnGap * (@columns - 1))) / @columns
+    @spaceLeft = @lineWidth
     @startX    = @document.x
     @startY    = @document.y
     @column    = 1


### PR DESCRIPTION
It's possible to trigger an infinite loop if the first words in a string are too long for the line. We end up trying to use `@spaceLeft` before it's initialized, which then causes us to break off too big a piece of the word, which causes `@spaceLeft` to go negative, which makes this loop run forever:

``` coffeescript
while w > @spaceLeft
  w = @wordWidth word.slice(0, --l)
```

To see the bug try running:

```
doc.text("COMPRESSION STOCKINGS KNEE-HIGH", {width: 64});
```
