### PR TITLE
Diminishing left-margin when inserting lists

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -117,7 +117,6 @@ module.exports =
           
     wrapper.wrap items.join('\n'), options
     
-    @x -= indent
     return this
     
   _initOptions: (x = {}, y, options = {}) ->


### PR DESCRIPTION
Every time when I insert a list, the x coordinate of the document moves to the left.

If I add add the following 3 lists to the document:
doc.list([1, 2, [1, 2]]);
doc.list([1, 2, [1, 2]]);
doc.list([1, 2, [1, 2]]);

then this is how the result looks like:

![diminishing-margins](https://cloud.githubusercontent.com/assets/1551034/5146055/212c26c6-71a0-11e4-9236-02d6b95aa8d6.png)

Not subtracting the indent after list insertion fixes this  problem.
