### PR TITLE
Fixes issue with continuedX sometimes not being reset by explicit line break.

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -46,6 +46,11 @@ class LineWrapper extends EventEmitter
       @lastLine = true
       
       @once 'line', =>
+        # when line has an explicit break, don't carry across
+        # the x continuation.
+        if @lineFinal
+          @lineFinal = false
+          @continuedX = @indent
         @document.y += options.paragraphGap or 0
         options.align = align
         @lastLine = false
@@ -137,6 +142,7 @@ class LineWrapper extends EventEmitter
               
       if bk.required or w > @spaceLeft
         if bk.required
+          @lineFinal = true
           @emit 'lastLine', options, this
           
         # if the user specified a max height and an ellipsis, and is about to pass the


### PR DESCRIPTION
Fixes issue with calls to text that have continued option not having continuedX reset when an explicit carriage return causes a break.

For example, if you paste this code into the [browser demo](http://pdfkit.org/demo/browser.html) you'll find that the subsequent lines do not have their position reset to the left edge of the column as expected.

```
// create a document and pipe to a blob
var doc = new PDFDocument();
var stream = doc.pipe(blobStream());

 doc.font('Times-Roman', 13)
       .text('First, we cause it to wrap onto the next', {
         width: 412,
         columns: 2,
         height: 300,
         continued: true,
         paragraphGap: 10
       });

for (var i = 0; i < 10; ++i) {
    doc.text('\nand then we cause it to wrap onto the next', {continued: i < 9});
}

// end and display the document in the iframe to the right
doc.end();
stream.on('finish', function() {
  iframe.src = stream.toBlobURL('application/pdf');
});
```
