### PR TITLE
Bugfix with text align in rtl languages

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -43,7 +43,12 @@ class LineWrapper extends EventEmitter
     # handle left aligning last lines of paragraphs
     @on 'lastLine', (options) =>
       align = options.align
-      options.align = 'left' if align is 'justify'
+
+      if options.dir is 'rtl' 
+        options.align = 'right' if align is 'justify'
+      else 
+        options.align = 'left' if align is 'justify'
+
       @lastLine = true
       
       @once 'line', =>

--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -43,11 +43,9 @@ class LineWrapper extends EventEmitter
     # handle left aligning last lines of paragraphs
     @on 'lastLine', (options) =>
       align = options.align
-
-      if options.dir is 'rtl' 
-        options.align = 'right' if align is 'justify'
-      else 
-        options.align = 'left' if align is 'justify'
+      
+      if options.align is 'justify'
+        options.align = if options.dir is 'rtl' then 'right' else 'left'
 
       @lastLine = true
       

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -165,7 +165,12 @@ module.exports =
     return if text.length is 0
 
     # handle options
-    align = options.align or 'left'
+    dir = if options.dir is 'rtl' then 'rtl' else 'ltr'
+    if dir is 'ltr'
+      align = options.align or 'left'
+    else
+      align = options.align or 'right'
+
     wordSpacing = options.wordSpacing or 0
     characterSpacing = options.characterSpacing or 0
 
@@ -173,7 +178,10 @@ module.exports =
     if options.width
       switch align
         when 'right'
-          textWidth = @widthOfString text.replace(/\s+$/, ''), options
+          lineEndingRegx = /\s+$/
+          lineEndingRegx = /^\s+/ if options.dir is 'rtl'
+          textWidth = @widthOfString text.replace(lineEndingRegx, ''), options
+
           x += options.lineWidth - textWidth
 
         when 'center'
@@ -240,6 +248,7 @@ module.exports =
     # used for embedded fonts.
     if wordSpacing
       words = text.trim().split(/\s+/)
+      words = words.reverse() if options.dir is 'rtl'
       wordSpacing += @widthOfString(' ') + characterSpacing
       wordSpacing *= 1000 / @_fontSize
       

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -179,7 +179,7 @@ module.exports =
       switch align
         when 'right'
           lineEndingRe = if options.dir is 'rtl' then /^\s+/ else /\s+$/
-          textWidth = @widthOfString text.replace(lineEndingRegx, ''), options
+          textWidth = @widthOfString text.replace(lineEndingRe, ''), options
 
           x += options.lineWidth - textWidth
 

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -166,11 +166,10 @@ module.exports =
     return if text.length is 0
 
     # handle options
-    dir = if options.dir is 'rtl' then 'rtl' else 'ltr'
-    if dir is 'ltr'
-      align = options.align or 'left'
-    else
+    if options.dir is 'rtl'
       align = options.align or 'right'
+    else
+      align = options.align or 'left'
 
     wordSpacing = options.wordSpacing or 0
     characterSpacing = options.characterSpacing or 0
@@ -179,8 +178,7 @@ module.exports =
     if options.width
       switch align
         when 'right'
-          lineEndingRegx = /\s+$/
-          lineEndingRegx = /^\s+/ if options.dir is 'rtl'
+          lineEndingRe = if options.dir is 'rtl' then /^\s+/ else /\s+$/
           textWidth = @widthOfString text.replace(lineEndingRegx, ''), options
 
           x += options.lineWidth - textWidth


### PR DESCRIPTION
I have added an attribute for `options` called `dir`, that defaults to `ltr`. if user set that option to `rtl` when using `text` method we needed to change the default text align to `right`. In `justify` mode we needed to align the last paragraph to the `right`.

Still we have a bug with calculating the correct line width for Arabic texts. seems the calculation does not take account the Arabic characters being reshaped. (the calculation is not correct but character reshaping is done right).

Also when the text is aligned to right and its direction is `rtl`, to calculate the line width we need to remove the spaces from the beginning of text not the end of it. so I changed code accordingly. without this changed right aligned texts in `rtl` mode always had a padding from right side.