### PR TITLE
Added Text margins and bgColor

### DIFF
--- a/docs/text.coffee.md
+++ b/docs/text.coffee.md
@@ -83,8 +83,8 @@ below.
 * `columnGap` - the amount of space between each column (1/4 inch by default)
 * `indent` - the amount in PDF points (72 per inch) to indent each paragraph of text
 * `paragraphGap` - the amount of space between each paragraph of text
-* `marginBefore` - the amount of space before the text
-* `marginAfter` - the amount of space after the text
+* `marginTop` - the amount of space before the text
+* `marginBottom` - the amount of space after the text
 * `lineGap` - the amount of space between each line of text
 * `wordSpacing` - the amount of space between each word in the text
 * `characterSpacing` - the amount of space between each character in the text

--- a/docs/text.coffee.md
+++ b/docs/text.coffee.md
@@ -90,6 +90,7 @@ below.
 * `fill` - whether to fill the text (`true` by default)
 * `stroke` - whether to stroke the text
 * `link` - a URL to link this text to (shortcut to create an annotation)
+* `bgColor` - a hex color to set the background of the text  
 * `underline` - whether to underline the text
 * `strike` - whether to strike out the text
 * `continued` - whether the text segment will be followed immediately by another segment. Useful for changing styling in the middle of a paragraph.

--- a/docs/text.coffee.md
+++ b/docs/text.coffee.md
@@ -82,6 +82,8 @@ below.
 * `columnGap` - the amount of space between each column (1/4 inch by default)
 * `indent` - the amount in PDF points (72 per inch) to indent each paragraph of text
 * `paragraphGap` - the amount of space between each paragraph of text
+* `marginBefore` - the amount of space before the text
+* `marginAfter` - the amount of space after the text
 * `lineGap` - the amount of space between each line of text
 * `wordSpacing` - the amount of space between each word in the text
 * `characterSpacing` - the amount of space between each character in the text

--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -30,6 +30,7 @@ class LineWrapper extends EventEmitter
       # we're continuing where we left off, indent that much
       # otherwise use the user specified indent option
       indent = @continuedX or @indent
+      @document.y += options.marginBefore || 0;
       @document.x += indent
       @lineWidth -= indent
       
@@ -47,7 +48,7 @@ class LineWrapper extends EventEmitter
       @lastLine = true
       
       @once 'line', =>
-        @document.y += options.paragraphGap or 0
+        @document.y += options.paragraphGap or options.marginAfter or 0
         options.align = align
         @lastLine = false
         

--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -30,7 +30,7 @@ class LineWrapper extends EventEmitter
       # we're continuing where we left off, indent that much
       # otherwise use the user specified indent option
       indent = @continuedX or @indent
-      @document.y += options.marginBefore || 0;
+      @document.y += options.marginTop || 0;
       @document.x += indent
       @lineWidth -= indent
       
@@ -48,7 +48,7 @@ class LineWrapper extends EventEmitter
       @lastLine = true
       
       @once 'line', =>
-        @document.y += options.paragraphGap or options.marginAfter or 0
+        @document.y += options.paragraphGap or options.marginTop or 0
         options.align = align
         @lastLine = false
         

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -189,7 +189,15 @@ module.exports =
           
     # calculate the actual rendered width of the string after word and character spacing
     renderedWidth = options.textWidth + (wordSpacing * (options.wordCount - 1)) + (characterSpacing * (text.length - 1))
-          
+    
+    # create bgColor annotations if the bgColor option is given
+    if options.bgColor
+      textWidth = @widthOfString(text.replace(/\s+$/, ''), options);
+      @save();
+      @rect(@x, @y, textWidth, @currentLineHeight());
+      @fill(options.bgColor)
+      @restore();
+
     # create link annotations if the link option is given
     if options.link
       @link x, y, renderedWidth, @currentLineHeight(), options.link


### PR DESCRIPTION
Added three extra options: marginBefore and marginAfter. It's very useful for creating gDoc styled documents. And Last but not least. I added the bgColor:"#ffff00" option to change the text background color in a color you provide. (Highlight conflicts in a several color combinations and has an other behaviour)

![screen shot 2016-11-23 at 14 20 59](https://cloud.githubusercontent.com/assets/1274858/20563172/aa7f3c82-b187-11e6-9532-be802752d9e0.png)
