### PR TITLE
Remove setTimeout call in PDFReference.finalize

### DIFF
--- a/lib/reference.js
+++ b/lib/reference.js
@@ -42,39 +42,36 @@ class PDFReference extends PDFAbstractReference {
   }
 
   finalize() {
-    return setTimeout(() => {
-      this.offset = this.document._offset;
+    this.offset = this.document._offset;
 
-      const encryptFn = this.document._security ? this.document._security.getEncryptFn(this.id, this.gen) : null;
+    const encryptFn = this.document._security ? this.document._security.getEncryptFn(this.id, this.gen) : null;
 
-      if (this.buffer.length) {
-        this.buffer = Buffer.concat(this.buffer);
-        if (this.compress) {
-          this.buffer = zlib.deflateSync(this.buffer);
-        }
-
-        if (encryptFn) {
-          this.buffer = encryptFn(this.buffer);
-        }
-
-        this.data.Length = this.buffer.length;
+    if (this.buffer.length) {
+      this.buffer = Buffer.concat(this.buffer);
+      if (this.compress) {
+        this.buffer = zlib.deflateSync(this.buffer);
       }
 
-      this.document._write(`${this.id} ${this.gen} obj`);
-      this.document._write(PDFObject.convert(this.data, encryptFn));
-
-      if (this.buffer.length) {
-        this.document._write('stream');
-        this.document._write(this.buffer);
-
-        this.buffer = []; // free up memory
-        this.document._write('\nendstream');
+      if (encryptFn) {
+        this.buffer = encryptFn(this.buffer);
       }
 
-      this.document._write('endobj');
-      return this.document._refEnd(this);
+      this.data.Length = this.buffer.length;
     }
-    , 0);
+
+    this.document._write(`${this.id} ${this.gen} obj`);
+    this.document._write(PDFObject.convert(this.data, encryptFn));
+
+    if (this.buffer.length) {
+      this.document._write('stream');
+      this.document._write(this.buffer);
+
+      this.buffer = []; // free up memory
+      this.document._write('\nendstream');
+    }
+
+    this.document._write('endobj');
+    this.document._refEnd(this);
   }
   toString() {
     return `${this.id} ${this.gen} R`;


### PR DESCRIPTION
This call is not necessary at all. The only consequence of it is that the Pages object will be written after other references, but makes no difference because how PDF object lookup works (using a table ref in the end of file)

On the other size will benefit performance of large documents