### PR TITLE
Use property getter to define PDFPage lazy dictionaries

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -95,25 +95,6 @@ class PDFPage {
     this.resources = this.document.ref({
       ProcSet: ['PDF', 'Text', 'ImageB', 'ImageC', 'ImageI']});
   
-    // Lazily create these dictionaries
-    Object.defineProperties(this, {
-      fonts: {
-        get: () => this.resources.data.Font != null ? this.resources.data.Font : (this.resources.data.Font = {})
-      },
-      xobjects: {
-        get: () => this.resources.data.XObject != null ? this.resources.data.XObject : (this.resources.data.XObject = {})
-      },
-      ext_gstates: {
-        get: () => this.resources.data.ExtGState != null ? this.resources.data.ExtGState : (this.resources.data.ExtGState = {})
-      },
-      patterns: {
-        get: () => this.resources.data.Pattern != null ? this.resources.data.Pattern : (this.resources.data.Pattern = {})
-      },
-      annotations: {
-        get: () => this.dictionary.data.Annots != null ? this.dictionary.data.Annots : (this.dictionary.data.Annots = [])
-      }
-    });
-  
     // The page dictionary
     this.dictionary = this.document.ref({
       Type: 'Page',
@@ -122,6 +103,32 @@ class PDFPage {
       Contents: this.content,
       Resources: this.resources
     });
+  }
+
+  // Lazily create these dictionaries
+  get fonts() {
+    const data = this.resources.data;
+    return data.Font != null ? data.Font : (data.Font = {});
+  }
+
+  get xobjects() {
+    const data = this.resources.data;
+    return data.XObject != null ? data.XObject : (data.XObject = {});
+  }
+
+  get ext_gstates() {
+    const data = this.resources.data;
+    return data.ExtGState != null ? data.ExtGState : (data.ExtGState = {});
+  }
+
+  get patterns() {
+    const data = this.resources.data;
+    return data.Pattern != null ? data.Pattern : (data.Pattern = {});
+  }
+
+  get annotations() {
+    const data = this.dictionary.data;
+    return data.Annots != null ? data.Annots : (data.Annots = []);
   }
     
   maxY() {


### PR DESCRIPTION
This saves memory per PDFPage instance. Also less, better compressible, code.