### PR TITLE
Use path.join for paths in inlined font files

### DIFF
--- a/lib/font/standard.js
+++ b/lib/font/standard.js
@@ -1,53 +1,54 @@
 import AFMFont from './afm';
 import PDFFont from '../font';
 import fs from 'fs';
+import path from 'path';
 
 // This insanity is so bundlers can inline the font files
 const STANDARD_FONTS = {
   Courier() {
-    return fs.readFileSync(__dirname + '/data/Courier.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Courier.afm'), 'utf8');
   },
   'Courier-Bold'() {
-    return fs.readFileSync(__dirname + '/data/Courier-Bold.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Courier-Bold.afm'), 'utf8');
   },
   'Courier-Oblique'() {
-    return fs.readFileSync(__dirname + '/data/Courier-Oblique.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Courier-Oblique.afm'), 'utf8');
   },
   'Courier-BoldOblique'() {
-    return fs.readFileSync(__dirname + '/data/Courier-BoldOblique.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Courier-BoldOblique.afm'), 'utf8');
   },
   Helvetica() {
-    return fs.readFileSync(__dirname + '/data/Helvetica.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Helvetica.afm'), 'utf8');
   },
   'Helvetica-Bold'() {
-    return fs.readFileSync(__dirname + '/data/Helvetica-Bold.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Helvetica-Bold.afm'), 'utf8');
   },
   'Helvetica-Oblique'() {
-    return fs.readFileSync(__dirname + '/data/Helvetica-Oblique.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Helvetica-Oblique.afm'), 'utf8');
   },
   'Helvetica-BoldOblique'() {
     return fs.readFileSync(
-      __dirname + '/data/Helvetica-BoldOblique.afm',
+      path.join(__dirname, '/data/Helvetica-BoldOblique.afm'),
       'utf8'
     );
   },
   'Times-Roman'() {
-    return fs.readFileSync(__dirname + '/data/Times-Roman.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Times-Roman.afm'), 'utf8');
   },
   'Times-Bold'() {
-    return fs.readFileSync(__dirname + '/data/Times-Bold.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Times-Bold.afm'), 'utf8');
   },
   'Times-Italic'() {
-    return fs.readFileSync(__dirname + '/data/Times-Italic.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Times-Italic.afm'), 'utf8');
   },
   'Times-BoldItalic'() {
-    return fs.readFileSync(__dirname + '/data/Times-BoldItalic.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Times-BoldItalic.afm'), 'utf8');
   },
   Symbol() {
-    return fs.readFileSync(__dirname + '/data/Symbol.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/Symbol.afm'), 'utf8');
   },
   ZapfDingbats() {
-    return fs.readFileSync(__dirname + '/data/ZapfDingbats.afm', 'utf8');
+    return fs.readFileSync(path.join(__dirname, '/data/ZapfDingbats.afm'), 'utf8');
   }
 };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Support for using pdfkit with pkg binaries.

**What is the current behavior?**
Pkg binary output does not include inlined font files because path.join isn't used, causes failures when trying to generate PDFs.

**What is the new behavior?**
Pkg binary includes inlined font files, PDF generation works as expected.
