### PR TITLE
Use valueOf when converting String object values

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -56,9 +56,9 @@ class PDFObject {
       // If so, encode it as big endian UTF-16
       let stringBuffer;
       if (isUnicode) {
-        stringBuffer = swapBytes(new Buffer(`\ufeff${string}`, 'utf16le'));
+        stringBuffer = swapBytes(Buffer.from(`\ufeff${string}`, 'utf16le'));
       } else {
-        stringBuffer = new Buffer(string, 'ascii');
+        stringBuffer = Buffer.from(string.valueOf(), 'ascii');
       }
 
       // Encrypt the string when necessary

--- a/tests/unit/object.spec.js
+++ b/tests/unit/object.spec.js
@@ -1,0 +1,23 @@
+const PDFObject = require('../../lib/object').default;
+
+describe('PDFObject', () => {
+  describe('convert', () => {
+    test('string literal', () => {
+      expect(PDFObject.convert('test')).toEqual('/test');
+    });
+
+    test('string literal with unicode', () => {
+      expect(PDFObject.convert('αβγδ')).toEqual('/αβγδ');
+    });
+
+    test('String object', () => {
+      expect(PDFObject.convert(new String('test'))).toEqual('(test)');
+    });
+
+    test('String object with unicode', () => {
+      const result = PDFObject.convert(new String('αβγδ'));
+      expect(result.length).toEqual(12);
+      expect(result).toMatchInlineSnapshot(`"(þÿ±²³´)"`);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
It uses valueOf when converting String objects

<!-- You can also link to an open issue here -->
**What is the current behavior?**
Fixes #923 

<!-- if this is a feature change -->
**What is the new behavior?**


<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Tests (preference for unit tests)
- [ ] Documentation
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->