### PR TITLE
Add fontLayoutCache option

### DIFF
--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -23,7 +23,9 @@ class EmbeddedFont extends PDFFont {
     this.lineGap = this.font.lineGap * this.scale;
     this.bbox = this.font.bbox;
 
-    this.layoutCache = Object.create(null);
+    if (document.options.fontCache !== false) {
+      this.layoutCache = Object.create(null);
+    }
   }
 
   layoutRun(text, features) {
@@ -43,6 +45,9 @@ class EmbeddedFont extends PDFFont {
   }
 
   layoutCached(text) {
+    if (!this.layoutCache) {
+      return this.layoutRun(text);
+    }
     let cached;
     if ((cached = this.layoutCache[text])) {
       return cached;

--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -23,7 +23,7 @@ class EmbeddedFont extends PDFFont {
     this.lineGap = this.font.lineGap * this.scale;
     this.bbox = this.font.bbox;
 
-    if (document.options.fontCache !== false) {
+    if (document.options.fontLayoutCache !== false) {
       this.layoutCache = Object.create(null);
     }
   }

--- a/tests/unit/font.spec.js
+++ b/tests/unit/font.spec.js
@@ -2,7 +2,7 @@ const PDFFontFactory = require('../../lib/font_factory').default;
 const PDFDocument = require('../../lib/document').default;
 
 describe('EmbeddedFont', () => {
-  test('no fontCache option', () => {
+  test('no fontLayoutCache option', () => {
     const document = new PDFDocument();
     const font = PDFFontFactory.open(
       document,
@@ -18,8 +18,8 @@ describe('EmbeddedFont', () => {
     expect(runSpy).toBeCalledTimes(1);
   });
 
-  test('fontCache = false', () => {
-    const document = new PDFDocument({ fontCache: false });
+  test('fontLayoutCache = false', () => {
+    const document = new PDFDocument({ fontLayoutCache: false });
     const font = PDFFontFactory.open(
       document,
       'tests/fonts/Roboto-Regular.ttf'

--- a/tests/unit/font.spec.js
+++ b/tests/unit/font.spec.js
@@ -1,0 +1,36 @@
+const PDFFontFactory = require('../../lib/font_factory').default;
+const PDFDocument = require('../../lib/document').default;
+
+describe('EmbeddedFont', () => {
+  test('no fontCache option', () => {
+    const document = new PDFDocument();
+    const font = PDFFontFactory.open(
+      document,
+      'tests/fonts/Roboto-Regular.ttf'
+    );
+    const runSpy = jest.spyOn(font, 'layoutRun');
+
+    font.layout('test');
+    font.layout('test');
+    font.layout('test');
+    font.layout('test');
+
+    expect(runSpy).toBeCalledTimes(1);
+  });
+
+  test('fontCache = false', () => {
+    const document = new PDFDocument({ fontCache: false });
+    const font = PDFFontFactory.open(
+      document,
+      'tests/fonts/Roboto-Regular.ttf'
+    );
+    const runSpy = jest.spyOn(font, 'layoutRun');
+
+    font.layout('test');
+    font.layout('test');
+    font.layout('test');
+    font.layout('test');
+
+    expect(runSpy).toBeCalledTimes(4);
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Add fontCache option

#932 

**What is the current behavior?**

The font layout is always cached

**What is the new behavior?**

If fontCache option is passed to document as false, the layout is not cached

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests (preference for unit tests)
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Pending: a better name? 
Edit: renamed to fontLayoutCache since is a technically more correct and to not confound with the font instance cache 