### PR TITLE
Update version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ### Unreleased
 
+### [v0.9.1] - 2019-3-04
+
 - Fix setting printing permission
 - Fix corruption of string objects in browser
 - Add option to set default font
 - Remove call to fontkit.openSync
 - Add standalone virtual file system implementation
+- Add option (fontLayoutCache) to disable font layout cache
 
 ### [v0.9.0] - 2019-1-28
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "document",
     "vector"
   ],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "http://pdfkit.org/",
   "author": {
     "name": "Devon Govett",


### PR DESCRIPTION
Update version with the following changes:

- Fix setting printing permission
- Fix corruption of string objects in browser
- Add option to set default font
- Remove call to fontkit.openSync
- Add standalone virtual file system implementation
- Add option (fontLayoutCache) to disable font layout cache

@devongovett can you take a look at it and publish?