### PR TITLE
Support for named destinations (ES6)

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -8,6 +8,7 @@ and some other properties. Here is a list of the available annotation methods:
 
 * `note(x, y, width, height, contents, options)`
 * `link(x, y, width, height, url, options)`
+* `goTo(x, y, w, h, name, options)`
 * `highlight(x, y, width, height, options)`
 * `underline(x, y, width, height, options)`
 * `strike(x, y, width, height, options)`
@@ -60,6 +61,9 @@ Here is an example that uses a few of the annotation types.
     doc.moveDown()
        .strike(20, doc.y, doc.widthOfString('STRIKE!'), height)
        .text('STRIKE!');
+
+    // Adding go to as annotation
+    doc.goTo(x, y, w, h, 'LINK', options);
 
 The output of this example looks like this.
 

--- a/docs/destinations.md
+++ b/docs/destinations.md
@@ -1,0 +1,29 @@
+# Destinations
+
+Anchor may specify a destination by `addNamedDestination(name, ...args)`, which consists of a page, the location of the display window on that page, and the zoom factor to use when displaying that page.
+
+Examples of creating anchor:
+
+    // Insert anchor for current page
+    doc.addNamedDestination('LINK');
+
+    // Insert anchor for current page with only horizontal magnified to fit where vertical top is 100
+    doc.addNamedDestination('LINK', 'FitH', 100);
+
+    // Insert anchor to display a portion of the current page, 1/2 inch in from the top and left and zoomed 50%
+    doc.addNamedDestination('LINK', 'XYZ', 36, 36, 50);
+
+    // Insert anchor for this text
+    doc.text('End of paragraph', { destination: 'ENDP' });
+
+
+Examples of go to link to anchor:
+
+    // Go to annotation
+    doc.goTo(10, 10, 100, 20, 'LINK')
+
+    // Go to annotation for this text
+    doc.text('Another goto', 20, 0, {
+   	  goTo: 'ENDP',
+   	  underline: true
+    });

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -194,30 +194,6 @@ capitalized.
 - `CreationDate` - the date the document was created (added automatically by PDFKit)
 - `ModDate` - the date the document was last modified
 
-## Destination
-
-Anchor may specify a destination by `addNamedDestination(name, ...args)`, which consists of a page, the location of the display window on that page, and the zoom factor to use when displaying that page.
-
-Examples:
-
-    // Insert anchor for current page
-    doc.addNamedDestination('LINK');
-
-    // Insert anchor for current page with only horizontal magnified to fit where vertical top is 100
-    doc.addNamedDestination('LINK', 'FitH', 100);
-
-    // Insert anchor to display a portion of the current page, 1/2 inch in from the top and left and zoomed 50%
-    doc.addNamedDestination('LINK', 'XYZ', 36, 36, 50);
-
-    // Insert anchor for this text
-    doc.text('End of paragraph', { destination: 'ENDP' });
-
-    // Go to annotation
-    doc.text('Another goto', 20, 0, {
-   	  goTo: 'ENDP',
-   	  underline: true
-    });
-
 ## Encryption and Access Privileges
 
 PDF specification allow you to encrypt the PDF file and require a password when opening the file,

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -194,6 +194,30 @@ capitalized.
 - `CreationDate` - the date the document was created (added automatically by PDFKit)
 - `ModDate` - the date the document was last modified
 
+## Destination
+
+Anchor may specify a destination by `addNamedDestination(name, ...args)`, which consists of a page, the location of the display window on that page, and the zoom factor to use when displaying that page.
+
+Examples:
+
+    // Insert anchor for current page
+    doc.addNamedDestination('LINK');
+
+    // Insert anchor for current page with only horizontal magnified to fit where vertical top is 100
+    doc.addNamedDestination('LINK', 'FitH', 100);
+
+    // Insert anchor to display a portion of the current page, 1/2 inch in from the top and left and zoomed 50%
+    doc.addNamedDestination('LINK', 'XYZ', 36, 36, 50);
+
+    // Insert anchor for this text
+    doc.text('End of paragraph', { destination: 'ENDP' });
+
+    // Go to annotation
+    doc.text('Another goto', 20, 0, {
+   	  goTo: 'ENDP',
+   	  underline: true
+    });
+
 ## Encryption and Access Privileges
 
 PDF specification allow you to encrypt the PDF file and require a password when opening the file,

--- a/docs/images.md
+++ b/docs/images.md
@@ -17,7 +17,7 @@ be scaled according to the following options.
 
 When a `fit` or `cover` array is provided, PDFKit accepts these additional options:
 
-* `align` - horizontally align the image, the possible values are `'left'`, `'center'` and `'right'` 
+* `align` - horizontally align the image, the possible values are `'left'`, `'center'` and `'right'`
 * `valign` - vertically align the image, the possible values are `'top'`, `'center'` and `'bottom'`
 
 Here is an example showing some of these options.
@@ -25,17 +25,17 @@ Here is an example showing some of these options.
     // Scale proprotionally to the specified width
     doc.image('images/test.jpeg', 0, 15, {width: 300})
        .text('Proportional to width', 0, 0);
-     
+
     // Fit the image within the dimensions
     doc.image('images/test.jpeg', 320, 15, {fit: [100, 100]})
        .rect(320, 15, 100, 100)
        .stroke()
        .text('Fit', 320, 0);
-      
+
     // Stretch the image
     doc.image('images/test.jpeg', 320, 145, {width: 200, height: 100})
        .text('Stretch', 320, 130);
-       
+
     // Scale the image
     doc.image('images/test.jpeg', 320, 280, {scale: 0.25})
        .text('Scale', 320, 265);
@@ -44,7 +44,7 @@ Here is an example showing some of these options.
     doc.image('images/test.jpeg', 430, 15, {fit: [100, 100], align: 'center', valign: 'center'})
        .rect(430, 15, 100, 100).stroke()
        .text('Centered', 430, 0);
-       
+
 * * *
 
 This example produces the following output:

--- a/docs/images.md
+++ b/docs/images.md
@@ -14,6 +14,9 @@ be scaled according to the following options.
 * `scale` factor provided - image is scaled proportionally by the provided scale factor
 * `fit` array provided - image is scaled proportionally to fit within the passed width and height
 * `cover` array provided - image is scaled proportionally to completely cover the rectangle defined by the passed width and height
+* `link` - a URL to link this image to (shortcut to create an annotation)
+* `goTo` - go to anchor (shortcut to create an annotation)
+* `destination` - create anchor to this image
 
 When a `fit` or `cover` array is provided, PDFKit accepts these additional options:
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -97,6 +97,8 @@ below.
 * `fill` - whether to fill the text (`true` by default)
 * `stroke` - whether to stroke the text
 * `link` - a URL to link this text to (shortcut to create an annotation)
+* `goTo` - go to anchor (shortcut to create an annotation)
+* `destination` - create anchor to this text
 * `underline` - whether to underline the text
 * `strike` - whether to strike out the text
 * `oblique` - whether to slant the text (angle in degrees or `true`)

--- a/docs/text.md
+++ b/docs/text.md
@@ -28,8 +28,8 @@ automatically inserts new pages as necessary so you don't have to worry about
 doing that for long pieces of text. PDFKit can also automatically wrap text
 into multiple columns.
 
-The text will automatically wrap unless you set the `lineBreak` option to `false`. 
-By default it will wrap to the page margin, but the `width` option allows 
+The text will automatically wrap unless you set the `lineBreak` option to `false`.
+By default it will wrap to the page margin, but the `width` option allows
 you to set a different width the text should be wrapped to.
 If you set the `height` option, the text will be clipped to the number of
 lines that can fit in that height.
@@ -38,37 +38,37 @@ When line wrapping is enabled, you can choose a text justification. There are
 four options: `left` (the default), `center`, `right`, and `justify`. They
 work just as they do in your favorite word processor, but here is an example
 showing their use in a text box.
-    
+
     const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam in suscipit purus.  Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vivamus nec hendrerit felis. Morbi aliquam facilisis risus eu lacinia. Sed eu leo in turpis fringilla hendrerit. Ut nec accumsan nisl.';
-    
+
     doc.fontSize(8);
     doc.text(`This text is left aligned. ${lorem}`, {
       width: 410,
       align: 'left'
     }
     );
-    
+
     doc.moveDown();
     doc.text(`This text is centered. ${lorem}`, {
       width: 410,
       align: 'center'
     }
     );
-    
+
     doc.moveDown();
-    doc.text(`This text is right aligned. ${lorem}`, { 
+    doc.text(`This text is right aligned. ${lorem}`, {
       width: 410,
       align: 'right'
     }
     );
-    
+
     doc.moveDown();
-    doc.text(`This text is justified. ${lorem}`, { 
+    doc.text(`This text is justified. ${lorem}`, {
       width: 410,
       align: 'justify'
     }
     );
-      
+
     // draw bounding rectangle
     doc.rect(doc.x, 0, 410, doc.y).stroke();
 
@@ -110,9 +110,9 @@ Additionally, the fill and stroke color and opacity methods described in the
 * * *
 
 Here is an example combining some of the options above, wrapping a piece of text into three columns, in a specified width and height.
-   
-    const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam in suscipit purus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vivamus nec hendrerit felis. Morbi aliquam facilisis risus eu lacinia. Sed eu leo in turpis fringilla hendrerit. Ut nec accumsan nisl. Suspendisse rhoncus nisl posuere tortor tempus et dapibus elit porta. Cras leo neque, elementum a rhoncus ut, vestibulum non nibh. Phasellus pretium justo turpis. Etiam vulputate, odio vitae tincidunt ultricies, eros odio dapibus nisi, ut tincidunt lacus arcu eu elit. Aenean velit erat, vehicula eget lacinia ut, dignissim non tellus. Aliquam nec lacus mi, sed vestibulum nunc. Suspendisse potenti. Curabitur vitae sem turpis. Vestibulum sed neque eget dolor dapibus porttitor at sit amet sem. Fusce a turpis lorem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;';   
-    
+
+    const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam in suscipit purus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vivamus nec hendrerit felis. Morbi aliquam facilisis risus eu lacinia. Sed eu leo in turpis fringilla hendrerit. Ut nec accumsan nisl. Suspendisse rhoncus nisl posuere tortor tempus et dapibus elit porta. Cras leo neque, elementum a rhoncus ut, vestibulum non nibh. Phasellus pretium justo turpis. Etiam vulputate, odio vitae tincidunt ultricies, eros odio dapibus nisi, ut tincidunt lacus arcu eu elit. Aenean velit erat, vehicula eget lacinia ut, dignissim non tellus. Aliquam nec lacus mi, sed vestibulum nunc. Suspendisse potenti. Curabitur vitae sem turpis. Vestibulum sed neque eget dolor dapibus porttitor at sit amet sem. Fusce a turpis lorem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;';
+
     doc.text(lorem, {
       columns: 3,
       columnGap: 15,
@@ -127,16 +127,16 @@ The output looks like this:
 
 ## Text measurements
 
-If you're working with documents that require precise layout, you may need to know the 
-size of a piece of text. PDFKit has two methods to achieve this: `widthOfString(text, options)` 
-and `heightOfString(text, options)`. Both methods use the same options described in the 
+If you're working with documents that require precise layout, you may need to know the
+size of a piece of text. PDFKit has two methods to achieve this: `widthOfString(text, options)`
+and `heightOfString(text, options)`. Both methods use the same options described in the
 Text styling section, and take into account the eventual line wrapping.
 
 ## Lists
 
-The `list` method creates a bulleted list. It accepts as arguments an array of strings, 
-and the optional `x`, `y` position. You can create complex multilevel lists by using nested arrays. 
-Lists use the following additional options: 
+The `list` method creates a bulleted list. It accepts as arguments an array of strings,
+and the optional `x`, `y` position. You can create complex multilevel lists by using nested arrays.
+Lists use the following additional options:
 
 * `bulletRadius`
 * `textIndent`
@@ -149,7 +149,7 @@ When set to true, PDFKit will retain the text wrapping state between `text` call
 when you call text again after changing the text styles, the wrapping will continue right
 where it left off.
 
-The options given to the first `text` call are also retained for subsequent calls after a 
+The options given to the first `text` call are also retained for subsequent calls after a
 `continued` one, but of course you can override them.  In the following example, the `width`
 option from the first `text` call is retained by the second call.
 
@@ -159,15 +159,15 @@ option from the first `text` call is retained by the second call.
          continued: true
        }).fillColor('red')
        .text(lorem.slice(500));
-       
+
 Here is the output:
-       
+
 ![4]()
 
 ## Fonts
 
-The PDF format defines 14 standard fonts that can be used in PDF documents. PDFKit supports each of them out of the box. 
-Besides Symbol and Zapf Dingbats this includes 4 styles (regular, bold, italic/oblique, bold+italic) of Helvetica, 
+The PDF format defines 14 standard fonts that can be used in PDF documents. PDFKit supports each of them out of the box.
+Besides Symbol and Zapf Dingbats this includes 4 styles (regular, bold, italic/oblique, bold+italic) of Helvetica,
 Courier, and Times. To switch between standard fonts, call the `font` method with the corresponding Label:
 
 * `'Courier'`
@@ -200,18 +200,18 @@ Here is an example showing how to set the font in each case.
 
     // Set the font size
     doc.fontSize(18);
-     
+
     // Using a standard PDF font
     doc.font('Times-Roman')
        .text('Hello from Times Roman!')
        .moveDown(0.5);
-     
-    // Using a TrueType font (.ttf)   
+
+    // Using a TrueType font (.ttf)
     doc.font('fonts/GoodDog.ttf')
        .text('This is Good Dog!')
        .moveDown(0.5);
-     
-    // Using a collection font (.ttc or .dfont)   
+
+    // Using a collection font (.ttc or .dfont)
     doc.font('fonts/Chalkboard.ttc', 'Chalkboard-Bold')
        .text('This is Chalkboard, not Comic Sans.');
 
@@ -225,7 +225,7 @@ every time you want to use it.
 
     // Register a font
     doc.registerFont('Heading Font', 'fonts/Chalkboard.ttc', 'Chalkboard-Bold');
-     
+
     // Use the font later
     doc.font('Heading Font')
        .text('This is a heading.');

--- a/lib/document.js
+++ b/lib/document.js
@@ -8,6 +8,7 @@ import fs from 'fs';
 import PDFObject from './object';
 import PDFReference from './reference';
 import PDFPage from './page';
+import PDFNameTree from './name_tree';
 import PDFSecurity from './security';
 import ColorMixin from './mixins/color';
 import VectorMixin from './mixins/vector';
@@ -76,9 +77,14 @@ class PDFDocument extends stream.Readable {
       return this.document._refEnd(this);
     };
 
+    const Names = this.ref({
+      Dests: new PDFNameTree()
+    });
+
     this._root = this.ref({
       Type: 'Catalog',
-      Pages
+      Pages,
+      Names
     });
 
     // The current page
@@ -185,6 +191,17 @@ class PDFDocument extends stream.Readable {
     }
   }
 
+  addNamedDestination(name, ...args) {
+    if (args.length === 0) {
+      args = ['XYZ', null, null, null];
+    }
+    if ((args[0] === 'XYZ') && (args[2] !== null)) {
+      args[2] = this.page.height - args[2];
+    }
+    args.unshift(this.page.dictionary);
+    this._root.data.Names.data.Dests.add(name, args);
+  }
+
   ref(data) {
     const ref = new PDFReference(this, this._offsets.length + 1, data);
     this._offsets.push(null); // placeholder for this object's offset once it is finalized
@@ -265,6 +282,7 @@ Please pipe the document into a Node stream.\
 
     this._root.end();
     this._root.data.Pages.end();
+    this._root.data.Names.end();
 
     if (this._security) {
       this._security.end();

--- a/lib/mixins/annotations.js
+++ b/lib/mixins/annotations.js
@@ -39,6 +39,19 @@ export default {
     return this.annotate(x, y, w, h, options);
   },
 
+  goTo(x, y, w, h, name, options) {
+    if (options == null) {
+      options = {};
+    }
+    options.Subtype = 'Link';
+    options.A = this.ref({
+      S: 'GoTo',
+      D: new String(name)
+    });
+    options.A.end();
+    return this.annotate(x, y, w, h, options);
+  },
+
   link(x, y, w, h, url, options) {
     if (options == null) {
       options = {};

--- a/lib/mixins/annotations.js
+++ b/lib/mixins/annotations.js
@@ -39,10 +39,7 @@ export default {
     return this.annotate(x, y, w, h, options);
   },
 
-  goTo(x, y, w, h, name, options) {
-    if (options == null) {
-      options = {};
-    }
+  goTo(x, y, w, h, name, options = {}) {
     options.Subtype = 'Link';
     options.A = this.ref({
       S: 'GoTo',

--- a/lib/mixins/images.js
+++ b/lib/mixins/images.js
@@ -91,6 +91,17 @@ export default {
       }
     }
 
+    // create link annotations if the link option is given
+    if (options.link != null) {
+      this.link(x, y, w, h, options.link);
+    }
+    if (options.goTo != null) {
+      this.goTo(x, y, w, h, options.goTo);
+    }
+    if (options.destination != null) {
+      this.addNamedDestination(options.destination, 'XYZ', x, y, null);
+    }
+
     // Set the current y position to below the image if it is in the document flow
     if (this.y === y) {
       this.y += h;

--- a/lib/mixins/text.js
+++ b/lib/mixins/text.js
@@ -337,6 +337,12 @@ export default {
     if (options.link != null) {
       this.link(x, y, renderedWidth, this.currentLineHeight(), options.link);
     }
+    if (options.goTo != null) {
+      this.goTo(x, y, renderedWidth, this.currentLineHeight(), options.goTo);
+    }
+    if (options.destination != null) {
+      this.addNamedDestination(options.destination, 'XYZ', x, y, null);
+    }
 
     // create underline or strikethrough line
     if (options.underline || options.strike) {

--- a/lib/name_tree.js
+++ b/lib/name_tree.js
@@ -1,0 +1,40 @@
+/*
+PDFNameTree - represents a name tree object
+*/
+
+import PDFObject from './object';
+
+class PDFNameTree {
+
+   constructor() {
+    this._items = {};
+  }
+
+   add(key, val) {
+    return this._items[key] = val;
+  }
+
+   get(key) {
+    return this._items[key];
+  }
+
+   toString() {
+    // Needs to be sorted by key
+    const sortedKeys = (Object.keys(this._items)).sort((a, b) => a.localeCompare(b));
+
+    const out = ['<<'];
+    if (sortedKeys.length > 1) {
+      const first = sortedKeys[0], last = sortedKeys[sortedKeys.length - 1];
+      out.push(`  /Limits ${PDFObject.convert([new String(first), new String(last)])}`);
+    }
+    out.push('  /Names [');
+    for (let key of sortedKeys) {
+      out.push(`    ${PDFObject.convert(new String(key))} ${PDFObject.convert(this._items[key])}`);
+    }
+    out.push(']');
+    out.push('>>');
+    return out.join('\n');
+  }
+ }
+
+export default PDFNameTree;

--- a/lib/name_tree.js
+++ b/lib/name_tree.js
@@ -6,19 +6,19 @@ import PDFObject from './object';
 
 class PDFNameTree {
 
-   constructor() {
+  constructor() {
     this._items = {};
   }
 
-   add(key, val) {
+  add(key, val) {
     return this._items[key] = val;
   }
 
-   get(key) {
+  get(key) {
     return this._items[key];
   }
 
-   toString() {
+  toString() {
     // Needs to be sorted by key
     const sortedKeys = (Object.keys(this._items)).sort((a, b) => a.localeCompare(b));
 
@@ -35,6 +35,6 @@ class PDFNameTree {
     out.push('>>');
     return out.join('\n');
   }
- }
+}
 
 export default PDFNameTree;

--- a/lib/object.js
+++ b/lib/object.js
@@ -4,6 +4,7 @@ By Devon Govett
 */
 
 import PDFAbstractReference from './abstract_reference';
+import PDFNameTree from './name_tree';
 
 const pad = (str, length) => (Array(length + 1).join('0') + str).slice(-length);
 
@@ -76,7 +77,7 @@ class PDFObject {
       // Buffers are converted to PDF hex strings
     } else if (Buffer.isBuffer(object)) {
       return `<${object.toString('hex')}>`;
-    } else if (object instanceof PDFAbstractReference) {
+    } else if (object instanceof PDFAbstractReference || object instanceof PDFNameTree) {
       return object.toString();
     } else if (object instanceof Date) {
       let string =

--- a/tests/unit/trailer.spec.js
+++ b/tests/unit/trailer.spec.js
@@ -19,15 +19,15 @@ describe('Document trailer', () => {
     const dataLog = [];
     const expected = [
       [
-        '7 0 obj',
-        '<<\n/Producer 8 0 R\n/Creator 9 0 R\n/CreationDate 10 0 R\n>>'
+        '8 0 obj',
+        '<<\n/Producer 9 0 R\n/Creator 10 0 R\n/CreationDate 11 0 R\n>>'
       ],
-      ['8 0 obj', '(PDFKit)'],
       ['9 0 obj', '(PDFKit)'],
-      ['10 0 obj', '(D:20180201000000Z)'],
+      ['10 0 obj', '(PDFKit)'],
+      ['11 0 obj', '(D:20180201000000Z)'],
       [
         'trailer',
-        `<<\n/Size 11\n/Root 2 0 R\n/Info 7 0 R\n/ID [<6d6f636b65642d7064662d6964> <6d6f636b65642d7064662d6964>]\n>>`
+        `<<\n/Size 12\n/Root 3 0 R\n/Info 8 0 R\n/ID [<6d6f636b65642d7064662d6964> <6d6f636b65642d7064662d6964>]\n>>`
       ]
     ];
     document._write = function(data) {

--- a/tests/unit/trailer.spec.js
+++ b/tests/unit/trailer.spec.js
@@ -44,4 +44,48 @@ describe('Document trailer', () => {
       done();
     }, 1);
   });
+
+  test('written empty data of destinations', done => {
+    const dataLog = [];
+    const expected = [
+      ['2 0 obj', '<<\n/Dests <<\n  /Names [\n]\n>>\n>>'],
+    ];
+    document._write = function(data) {
+      dataLog.push(data);
+    };
+    document.end();
+    setTimeout(() => {
+      console.log(dataLog);
+      for (let i = 0; i < expected.length; ++i) {
+        let idx = dataLog.indexOf(expected[i][0]);
+        for (let j = 1; j < expected[i].length; ++j) {
+          expect(dataLog[idx + j]).toEqual(expected[i][j]);
+        }
+      }
+      done();
+    }, 1);
+  });
+
+  test('written data of destinations', done => {
+    document.addNamedDestination('LINK');
+
+    const dataLog = [];
+    const expected = [
+      ['2 0 obj', '<<\n/Dests <<\n  /Names [\n    (LINK) [7 0 R /XYZ null null null]\n]\n>>\n>>'],
+    ];
+    document._write = function(data) {
+      dataLog.push(data);
+    };
+    document.end();
+    setTimeout(() => {
+      console.log(dataLog);
+      for (let i = 0; i < expected.length; ++i) {
+        let idx = dataLog.indexOf(expected[i][0]);
+        for (let j = 1; j < expected[i].length; ++j) {
+          expect(dataLog[idx + j]).toEqual(expected[i][j]);
+        }
+      }
+      done();
+    }, 1);
+  });
 });

--- a/tests/unit/trailer.spec.js
+++ b/tests/unit/trailer.spec.js
@@ -55,7 +55,6 @@ describe('Document trailer', () => {
     };
     document.end();
     setTimeout(() => {
-      console.log(dataLog);
       for (let i = 0; i < expected.length; ++i) {
         let idx = dataLog.indexOf(expected[i][0]);
         for (let j = 1; j < expected[i].length; ++j) {
@@ -67,18 +66,31 @@ describe('Document trailer', () => {
   });
 
   test('written data of destinations', done => {
-    document.addNamedDestination('LINK');
+    document.addNamedDestination('LINK1');
+    document.addNamedDestination('LINK2', 'FitH', 100);
+    document.addNamedDestination('LINK3', 'XYZ', 36, 36, 50);
 
     const dataLog = [];
     const expected = [
-      ['2 0 obj', '<<\n/Dests <<\n  /Names [\n    (LINK) [7 0 R /XYZ null null null]\n]\n>>\n>>'],
+      [
+        '2 0 obj',
+        `<<
+/Dests <<
+  /Limits [(LINK1) (LINK3)]
+  /Names [
+    (LINK1) [7 0 R /XYZ null null null]
+    (LINK2) [7 0 R /FitH 100]
+    (LINK3) [7 0 R /XYZ 36 756 50]
+]
+>>
+>>`
+      ]
     ];
     document._write = function(data) {
       dataLog.push(data);
     };
     document.end();
     setTimeout(() => {
-      console.log(dataLog);
       for (let i = 0; i < expected.length; ++i) {
         let idx = dataLog.indexOf(expected[i][0]);
         for (let j = 1; j < expected[i].length; ++j) {

--- a/tests/unit/trailer.spec.js
+++ b/tests/unit/trailer.spec.js
@@ -69,6 +69,7 @@ describe('Document trailer', () => {
     document.addNamedDestination('LINK1');
     document.addNamedDestination('LINK2', 'FitH', 100);
     document.addNamedDestination('LINK3', 'XYZ', 36, 36, 50);
+    document.goTo(10, 10, 100, 20, 'LINK1');
 
     const dataLog = [];
     const expected = [
@@ -83,6 +84,17 @@ describe('Document trailer', () => {
     (LINK3) [7 0 R /XYZ 36 756 50]
 ]
 >>
+>>`
+      ],
+      [
+        '7 0 obj',
+        `<<
+/Type /Page
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Contents 5 0 R
+/Resources 6 0 R
+/Annots [9 0 R]
 >>`
       ]
     ];


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Add support for named destinations.
This is rewrited PR https://github.com/foliojs/pdfkit/pull/720 to ES6 and fixed destinations for images.


**What is the current behavior?**

Does not allow named destinations.

**What is the new behavior?**

This basically allows you to link to things before they are defined - so you could create a ToC based on some defined heading names, instead of page numbers (which may change as the document evolves).

All usages and example is in https://github.com/foliojs/pdfkit/pull/720.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests (preference for unit tests)
- [x] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->