### PR TITLE
Changed new PDFDocument to new PDFDocument().

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Installation uses the [npm](http://npmjs.org/) package manager.  Just type the f
 const PDFDocument = require('pdfkit');
 
 // Create a document
-const doc = new PDFDocument;
+const doc = new PDFDocument();
 
 // Pipe its output somewhere, like to a file or HTTP response
 // See below for browser usage
@@ -137,7 +137,7 @@ const PDFDocument = require('pdfkit');
 const blobStream  = require('blob-stream');
 
 // create a document the same way as above
-const doc = new PDFDocument;
+const doc = new PDFDocument();
 
 // pipe the document to a blob
 const stream = doc.pipe(blobStream());


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will update README file a bit.
Current code examples shown in readme file do not call the function constructor of PDFDocument.
I've just changed `new PDFDocument` to `new PDFDocument()`.

**What is the current behavior?** N/A
**What is the new behavior?** N/A

**Checklist**:

- [ ] Tests (preference for unit tests)
- [x] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged 