### PR TITLE
Fix links to page numbers within the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix setting printing permission
 - Fix corruption of string objects in browser
+- Fix links to pages within the document
 - Add option to set default font
 - Remove call to fontkit.openSync
 - Add standalone virtual file system implementation

--- a/lib/document.js
+++ b/lib/document.js
@@ -60,22 +60,6 @@ class PDFDocument extends stream.Readable {
       Kids: []
     });
 
-    Pages.finalize = function() {
-      this.offset = this.document._offset;
-      this.document._write(this.id + ' ' + this.gen + ' obj');
-      this.document._write('<<');
-      this.document._write('/Type /Pages');
-      this.document._write(`/Count ${this.data.Count}`);
-      this.document._write(
-        `/Kids [${Buffer.concat(this.data.Kids)
-          .slice(0, -1)
-          .toString()}]`
-      );
-      this.document._write('>>');
-      this.document._write('endobj');
-      return this.document._refEnd(this);
-    };
-
     this._root = this.ref({
       Type: 'Catalog',
       Pages
@@ -140,7 +124,7 @@ class PDFDocument extends stream.Readable {
 
     // add the page to the object store
     const pages = this._root.data.Pages.data;
-    pages.Kids.push(new Buffer(this.page.dictionary + ' '));
+    pages.Kids.push(this.page.dictionary);
     pages.Count++;
 
     // reset x and y coordinates


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Links to page numbers do not trigger navigation when clicked.

**Checklist**:
- [x] Update CHANGELOG.md
- [x] Ready to be merged 
- [ ] Tests - I'm not sure how you'd like to add tests for this. I'd be willing to add some if you have suggestions though 😄
- [ ] Documentation - I don't think any update is needed for this fix.

**Code Sample**
```
"use strict";
var fs = require('fs');
var PDFDocument = require('./js/pdfkit');

var doc = new PDFDocument({bufferPages: true});
doc.text("First Page");
doc.addPage();
doc.text('Go To First Page', {link: 0});
doc.end();
doc.pipe(fs.createWriteStream('/tmp/result.pdf'));
```

**Low Level Details**
Without this fix, the link annotation generates a command like this:
```
/S /GoTo
/D [<362030205220> /XYZ null null null]
```

With the fix, the link annotation correctly generates a PDF comand like this:
```
/S /GoTo
/D [6 0 R /XYZ null null null]
```

This comes from the [mixins/annotations:link()](https://github.com/foliojs/pdfkit/blob/a6af76467ce06bd6a2af4aa7271ccac9ff152a7d/lib/mixins/annotations.js#L54) method expecting a `Kid` to be a PDFReference and not a Buffer. 

Changing the `Kids` to be stored as PDF references also allowed the `Pages` object to use it's normal finalize method instead of requiring a custom implementation to output the Kids array correctly.