### PR TITLE
Fix object index in annotation test

### DIFF
--- a/tests/unit/annotations.spec.js
+++ b/tests/unit/annotations.spec.js
@@ -28,10 +28,10 @@ describe('Annotations', () => {
 
       const expected = [
         [
-          `10 0 obj`,
+          `11 0 obj`,
           `<<
 /S /GoTo
-/D [6 0 R /XYZ null null null]
+/D [7 0 R /XYZ null null null]
 >>`
         ]
       ];


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix a test failling due to a object index shift
