### PR TITLE
Added fs module in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Installation uses the [npm](http://npmjs.org/) package manager.  Just type the f
 
 ```javascript
 const PDFDocument = require('pdfkit');
+const fs = require('fs');
 
 // Create a document
 const doc = new PDFDocument();


### PR DESCRIPTION
Previous code for throwing error if copy and then pasted. 
So I have included "fs" module as well in the example code.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
This PR is about docs update

<!-- You can also link to an open issue here -->

**What is the current behavior?**
If someone copy and pastes the example code, it throws an error as "fs" is not defined.

<!-- if this is a feature change -->

**What is the new behavior?**
Now, there is no error like "fs" is not defined.  User just need to change the font and image paths in the example code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests (preference for unit tests)
- [x] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
