### PR TITLE
throw errors when invalid values passed to dash(...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix links to pages within the document
 - Add support for named destinations
+- Throw errors when `dash(...)` is passed invalid lengths
 
 ### [v0.9.1] - 2019-04-30
 

--- a/docs/vector.md
+++ b/docs/vector.md
@@ -145,7 +145,8 @@ The output of this example looks like this.
 
 The `dash` method allows you to create non-continuous dashed lines. It takes a
 length specifying how long each dash should be, as well as an optional hash
-describing the additional properties `space` and `phase`.
+describing the additional properties `space` and `phase`. Lengths must be positive
+numbers; `dash` will throw if passed invalid lengths.
 
 The `space` option defines the length of the space between each dash, and the `phase` option
 defines the starting point of the sequence of dashes. By default the `space`

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -72,7 +72,7 @@ export default {
     if(!valid) {
       throw new Error(`dash(${JSON.stringify(originalLength)}, ${JSON.stringify(options)}) invalid, lengths must be numeric and greater than zero`);
     }
-    length = length.map(v => number(v)).join(' ');
+    length = length.map(number).join(' ');
     phase = options.phase || 0;
     return this.addContent(`[${length}] ${number(phase)} d`);
   },

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -63,20 +63,18 @@ export default {
 
   dash(length, options = {}) {
     let phase;
-    if (length == null) {
-      return this;
+    const originalLength = length;
+    if (!Array.isArray(length)) {
+      length = [length, options.space || length];
     }
-    if (Array.isArray(length)) {
-      length = length.map(v => number(v)).join(' ');
-      phase = options.phase || 0;
-      return this.addContent(`[${length}] ${number(phase)} d`);
-    } else {
-      const space = options.space != null ? options.space : length;
-      phase = options.phase || 0;
-      return this.addContent(
-        `[${number(length)} ${number(space)}] ${number(phase)} d`
-      );
+
+    const valid = length.every(x => Number.isFinite(x) && x > 0);
+    if(!valid) {
+      throw new Error(`dash(${JSON.stringify(originalLength)}, ${JSON.stringify(options)}) invalid, lengths must be numeric and greater than zero`);
     }
+    length = length.map(v => number(v)).join(' ');
+    phase = options.phase || 0;
+    return this.addContent(`[${length}] ${number(phase)} d`);
   },
 
   undash() {

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -62,7 +62,6 @@ export default {
   },
 
   dash(length, options = {}) {
-    let phase;
     const originalLength = length;
     if (!Array.isArray(length)) {
       length = [length, options.space || length];
@@ -72,9 +71,9 @@ export default {
     if(!valid) {
       throw new Error(`dash(${JSON.stringify(originalLength)}, ${JSON.stringify(options)}) invalid, lengths must be numeric and greater than zero`);
     }
+
     length = length.map(number).join(' ');
-    phase = options.phase || 0;
-    return this.addContent(`[${length}] ${number(phase)} d`);
+    return this.addContent(`[${length}] ${number(options.phase || 0)} d`);
   },
 
   undash() {

--- a/tests/unit/document.spec.js
+++ b/tests/unit/document.spec.js
@@ -32,5 +32,4 @@ describe('PDFDocument', () => {
       expect(fontSpy).not.toBeCalled();
     });
   });
-
 });

--- a/tests/unit/document.spec.js
+++ b/tests/unit/document.spec.js
@@ -32,4 +32,5 @@ describe('PDFDocument', () => {
       expect(fontSpy).not.toBeCalled();
     });
   });
+
 });

--- a/tests/unit/vector.spec.js
+++ b/tests/unit/vector.spec.js
@@ -111,5 +111,50 @@ describe('Vector Graphics', () => {
         `endobj`
       ]);
     });
+
+    describe('validation', () => {
+
+      test('length 1', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash(1)).not.toThrow();
+      });
+
+      test('length 1.5', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash(1.5)).not.toThrow();
+      });
+
+      test('length 0 throws', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash(0)).toThrow('dash(0, {}) invalid, lengths must be numeric and greater than zero');
+      });
+
+      test('length -1 throws', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash(-1)).toThrow('dash(-1, {}) invalid, lengths must be numeric and greater than zero');
+      });
+
+      test('length null throws', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash(null)).toThrow('dash(null, {}) invalid, lengths must be numeric and greater than zero');
+      });
+
+      test('length array', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash([2,3])).not.toThrow();
+      });
+
+      test('length array containing zeros throws', () => {
+        const doc = new PDFDocument();
+
+        expect(() => doc.dash([2, 0, 3])).toThrow('dash([2,0,3], {}) invalid, lengths must be numeric and greater than zero');
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->

**The dash(...) function now throws errors when passed invalid values**

<!-- You can also link to an open issue here -->
Fixes #949. Current behavior is that `dash(...)` accepts values such as `0` for length, which breaks rendering in some viewers. There is a demo in the linked issue of the impact of the problem.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests (preference for unit tests)
- [x] Documentation
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
