### PR TITLE
Fix #477, Trying to print outside of margins causes pdfkit to hang (infinite loop)

### DIFF
--- a/lib/mixins/text.js
+++ b/lib/mixins/text.js
@@ -218,7 +218,8 @@ export default {
     // wrap to margins if no x or y position passed
     if (result.lineBreak !== false) {
       if (result.width == null) {
-        result.width = this.page.width - this.x - this.page.margins.right;
+        // width should never be negative!
+        result.width = Math.max(0, this.page.width - this.x - this.page.margins.right);
       }
     }
 


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
This is a bug fix.

**What kind of change does this PR introduce?**

Fix #477

**What is the current behavior?**

When wrapping text, and trying to write outside current page limits, an infinite loop hangs.

**What is the new behavior?**

Caused by leaving a `width` fall on a negative value.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests (preference for unit tests) npm run test:unit passes
- [ ] Documentation "N/A"
- [ ] Update CHANGELOG.md "N/A"
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

