### PR TITLE
Add support for inserting pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Unreleased
  - Fix infinite loop when text is positioned after page right margin
 
+### [v0.11.0] - 2019-07-09 [Joost Lubach]
+
+- Added support for inserting pages
+
 ### [v0.10.0] - 2019-06-06
 
 - Fix links to pages within the document

--- a/lib/document.js
+++ b/lib/document.js
@@ -147,6 +147,53 @@ class PDFDocument extends stream.Readable {
     return this;
   }
 
+  insertPage(at, options) {
+    // end the current page if needed
+    if (options == null) {
+      ({ options } = this);
+    }
+    if (!this.options.bufferPages) {
+      throw new Error("Cannot insert pages without option 'bufferPages'")
+    }
+
+    // create a page object
+    this.page = new PDFPage(this, options);
+    this._pageBuffer.splice(at, 0, this.page);
+
+    // add the page to the object store
+    const pages = this._root.data.Pages.data;
+    pages.Kids.splice(at, 0, this.page.dictionary);
+    pages.Count++;
+
+    // reset x and y coordinates
+    this.x = this.page.margins.left;
+    this.y = this.page.margins.top;
+
+    // flip PDF coordinate system so that the origin is in
+    // the top left rather than the bottom left
+    this._ctm = [1, 0, 0, 1, 0, 0];
+    this.transform(1, 0, 0, -1, 0, this.page.height);
+
+    this.emit('pageAdded');
+
+    return this;
+  }
+
+  addPageAfterThis(options) {
+    if (!this.options.bufferPages) {
+      this.addPage(options);
+      return;
+    }
+
+    const index = this._pageBuffer.indexOf(this.page);
+    if (index === -1) {
+      this.addPage(options);
+      return;
+    }
+
+    this.insertPage(index + 1, options);
+  }
+
   bufferedPageRange() {
     return { start: this._pageBufferStart, count: this._pageBuffer.length };
   }

--- a/lib/line_wrapper.js
+++ b/lib/line_wrapper.js
@@ -305,7 +305,7 @@ class LineWrapper extends EventEmitter {
         return false;
       }
 
-      this.document.addPage();
+      this.document.addPageAfterThis();
       this.column = 1;
       this.startY = this.document.page.margins.top;
       this.maxY = this.document.page.maxY();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "document",
     "vector"
   ],
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "http://pdfkit.org/",
   "author": {
     "name": "Devon Govett",


### PR DESCRIPTION
I've added a change that allows pages to be inserted through an `insertPage(at, options)` method.

Also, when continuing pages, it will try to insert a page after the current one.

It will throw an error if option `bufferPages` is not set.