### PR TITLE
Fix bug with undefined / null document properties crashing `new PDFDocument`

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -14,7 +14,7 @@ class PDFSecurity {
       if (!info.hasOwnProperty(key)) {
         continue;
       }
-      infoStr += `${key}: ${String(info[key])}\n`;
+      infoStr += `${key}: ${info[key]}\n`;
     }
 
     return wordArrayToBuffer(CryptoJS.MD5(infoStr));

--- a/lib/security.js
+++ b/lib/security.js
@@ -14,7 +14,7 @@ class PDFSecurity {
       if (!info.hasOwnProperty(key)) {
         continue;
       }
-      infoStr += `${key}: ${info[key].toString()}\n`;
+      infoStr += `${key}: ${String(info[key])}\n`;
     }
 
     return wordArrayToBuffer(CryptoJS.MD5(infoStr));

--- a/tests/unit/document.spec.js
+++ b/tests/unit/document.spec.js
@@ -32,4 +32,19 @@ describe('PDFDocument', () => {
       expect(fontSpy).not.toBeCalled();
     });
   });
+
+  describe('document info', () => {
+    
+    test('accepts properties with value undefined', () => {
+      expect(() => new PDFDocument({ info: { Title: undefined }}))
+        .not.toThrow(new TypeError("Cannot read property 'toString' of undefined"));
+    });
+    
+    test('accepts properties with value null', () => {
+      expect(() => new PDFDocument({ info: { Title: null }}))
+        .not.toThrow(new TypeError("Cannot read property 'toString' of null"));
+    });
+    
+  });
+
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bug fix.

**What is the current behavior?**

The following document definition results in `TypeError("Cannot read property 'toString' of undefined"))`:

    new PDFDocument({
     info: {
      Title: undefined,
     },
    });

**What is the new behavior?**

This fix will replace `<var>.toString()` with `String(<var>)`, which handles undefined and null gracefully.

**Checklist**:

- [x] Tests (preference for unit tests)
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md N/A
- [x] Ready to be merged 
