### PR TITLE
Fix interlaced PNGs

### DIFF
--- a/lib/image/png.js
+++ b/lib/image/png.js
@@ -1,10 +1,64 @@
 import zlib from 'zlib';
-import PNG from 'png-js';
+import PNG from 'upng-js';
+
+PNG.load = function(data) {
+  try {
+    const decodedData = PNG.decode(data);
+
+    decodedData.palette = [];
+    decodedData.transparency = {};
+    decodedData.animation = null;
+    decodedData.text = {};
+
+    decodedData.imgData = decodedData.data;
+    decodedData.data = data;
+    decodedData.colorType = decodedData.ctype;
+
+    decodedData.colors = function() {
+      switch (decodedData.colorType) {
+        case 0:
+        case 3:
+        case 4:
+          return 1;
+        case 2:
+        case 6:
+          return 3;
+        default:
+      }
+    }.call(this);
+
+    decodedData.colorSpace = function() {
+      switch (decodedData.colors) {
+        case 1:
+          return 'DeviceGray';
+        case 3:
+          return 'DeviceRGB';
+        default:
+      }
+    }.call(this);
+
+    decodedData.bits = decodedData.depth;
+    decodedData.compressionMethod = decodedData.compress;
+    decodedData.filterMethod = decodedData.filter;
+    decodedData.interlaceMethod = decodedData.interlace;
+
+    if (decodedData.tabs['PLTE'])
+      decodedData.palette = decodedData.tabs['PLTE'];
+
+    decodedData.pixelBitlength = decodedData.bits * decodedData.colors;
+    decodedData.hasAlphaChannel =
+      decodedData.colorType === 4 || decodedData.colorType === 6;
+
+    return decodedData;
+  } catch (e) {
+    return false;
+  }
+};
 
 class PNGImage {
   constructor(data, label) {
     this.label = label;
-    this.image = new PNG(data);
+    this.image = PNG.load(data);
     this.width = this.image.width;
     this.height = this.image.height;
     this.imgData = this.image.imgData;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "crypto-js": "^3.1.9-1",
     "fontkit": "^1.0.0",
     "linebreak": "^0.3.0",
-    "png-js": ">=0.1.0"
+    "upng-js": "^2.1.0"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ const external = [
   'fontkit',
   'events',
   'linebreak',
-  'png-js',
+  'upng-js',
   'crypto-js',
   'saslprep'
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4605,6 +4605,11 @@ pako@^0.2.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
   integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
+pako@^1.0.5:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+
 pako@~1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
@@ -4750,11 +4755,6 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-
-png-js@>=0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/png-js/-/png-js-0.1.1.tgz#1cc7c212303acabe74263ec3ac78009580242d93"
-  integrity sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM=
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -6127,6 +6127,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+upng-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/upng-js/-/upng-js-2.1.0.tgz#7176e73973db361ca95d0fa14f958385db6b9dd2"
+  integrity sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==
+  dependencies:
+    pako "^1.0.5"
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**

We want to replace png-js with UPNG.js in order to provide support for interlaced PNGS. `png-js` hasn't had an updated in 7 years and `UPNG.js` has recent updates but any library that supports interlaced PNGs would be good. https://github.com/foliojs/pdfkit/issues/926

**What is the current behavior?**

Interlaced PNGs fail to load and crash the PDF.

**What is the new behavior?**

Interlaced PNGs should render.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests (preference for unit tests)
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [ ] Ready to be merged

<!-- feel free to add additional comments -->

This PR doesn't currently work. I don't have enough knowledge to replace the transparency and decodePixel `png-js` methods using UPNG.js but I thought I'd get the ball rolling.

@blikblum or @devongovett if you could help that would be great.

<!-- Thank you for contributing! -->
