### PR TITLE
Add times font alias

### DIFF
--- a/lib/font/standard.js
+++ b/lib/font/standard.js
@@ -31,6 +31,9 @@ const STANDARD_FONTS = {
       'utf8'
     );
   },
+  Times() {
+    return fs.readFileSync(__dirname + '/data/Times-Roman.afm', 'utf8');
+  },
   'Times-Roman'() {
     return fs.readFileSync(__dirname + '/data/Times-Roman.afm', 'utf8');
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds aliases to the Times New Roman font.

**What is the current behavior?**
To use the font, users need to call 'Times-Roman', 'Times-Italic' or 'Times-Bold' which is inconsistent with other fonts, like ''Courier', 'Courier-Italic' or 'Courier-Bold'.

**What is the new behavior?**
The user can now simply call 'Times'

**Checklist**:

- [ ] Tests (preference for unit tests) N/A
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [ ] Ready to be merged