### PR TITLE
Explicitly define default value for CIDToGIDMap

### DIFF
--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -185,9 +185,9 @@ class EmbeddedFont extends PDFFont {
 
     descriptor.end();
 
-    const descendantFont = this.document.ref({
+    const descendantFontData = {
       Type: 'Font',
-      Subtype: isCFF ? 'CIDFontType0' : 'CIDFontType2',
+      Subtype: 'CIDFontType0',
       BaseFont: name,
       CIDSystemInfo: {
         Registry: new String('Adobe'),
@@ -196,7 +196,14 @@ class EmbeddedFont extends PDFFont {
       },
       FontDescriptor: descriptor,
       W: [0, this.widths]
-    });
+    };
+
+    if (!isCFF) {
+      descendantFontData.Subtype = 'CIDFontType2';
+      descendantFontData.CIDToGIDMap = 'Identity';
+    }
+
+    const descendantFont = this.document.ref(descendantFontData);
 
     descendantFont.end();
 


### PR DESCRIPTION
I'm using PDFKit to make PDF/A - 3B documents. Thanks to PDFKit's API it's not too difficult to do, but I've come across a minor issue which cannot be solved via the API.

**What kind of change does this PR introduce?**

CIDToGIDMap is an optional property of Type 2 CIDFonts with a default value of "Identity"<sup>1</sup>. However, the property is required by the PDF/A specification<sup>2</sup>. Defining this property does not change the behaviour of PDF 1.3 to 1.7 documents but does allow PDFKit to be used to generate valid PDF/A files.

1. PDF 1.7 specification §9.7.4.1
2. [ISO 19005-3 clause 6.2.11.3 test 2](https://github.com/veraPDF/veraPDF-validation-profiles/wiki/PDFA-Parts-2-and-3-rules#rule-62113-2)

**What is the current behavior?**

CIDToGIDMap property is not set so viewers will presume "Identity" by default.

**What is the new behavior?**

CIDToGIDMap is property is explicitly set to "Identity".

**Checklist**:

- [x] Tests (preference for unit tests) - Unit tests run. Integration tests seem to be failing before change as all references are off by one. Results look okay otherwise.
- [ ] Documentation - N/A
- [ ] Update CHANGELOG.md - N/A? let me know if it's required for this minor change
- [x] Ready to be merged

This is my first PR so feedback is welcome.

Related to https://github.com/foliojs/pdfkit/issues/369.
