### PR TITLE
Set link annotation flag to print by default

### DIFF
--- a/lib/mixins/annotations.js
+++ b/lib/mixins/annotations.js
@@ -3,6 +3,11 @@ export default {
     options.Type = 'Annot';
     options.Rect = this._convertRect(x, y, w, h);
     options.Border = [0, 0, 0];
+
+    if (options.Subtype === 'Link' && typeof options.F === 'undefined') {
+      options.F = 1 << 2; // Print Annotaion Flag
+    }
+
     if (options.Subtype !== 'Link') {
       if (options.C == null) {
         options.C = this._normalizeColor(options.color || [0, 0, 0]);

--- a/lib/mixins/annotations.js
+++ b/lib/mixins/annotations.js
@@ -5,7 +5,7 @@ export default {
     options.Border = [0, 0, 0];
 
     if (options.Subtype === 'Link' && typeof options.F === 'undefined') {
-      options.F = 1 << 2; // Print Annotaion Flag
+      options.F = 1 << 2; // Print Annotation Flag
     }
 
     if (options.Subtype !== 'Link') {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The PDF/A specification requires that the annotation flag for links be set to "print". In other words a document must look the same whether it's viewed on screen or printed. This change sets the annotation flag of links to print by default allowing PDFKit's helper methods, such as the one below, to be used to create valid PDF/A documents. Since links are invisible rectangles, setting this flag does not actually affect the appearance of printed documents.

```
doc.text('PDF/A compatible link', 20, 0, { link: 'http://example.com/' });
```

References:
- PDF 1.7 specification §12.5.3
- [PDF/A-2 and PDF/A-3 validation rule 6.3.2-1](https://docs.verapdf.org/validation/pdfa-parts-2-and-3/#rule-632-1)
- [PDF/A-2 and PDF/A-3 validation rule 6.3.2-2](https://docs.verapdf.org/validation/pdfa-parts-2-and-3/#rule-632-2)

**What is the current behavior?**

Annotation flag is not set.

**What is the new behavior?**

Annotation flag for links is set to print by default.

**Checklist**:

- [x] Tests (preference for unit tests)
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md N/A
- [x] Ready to be merged

Related to https://github.com/foliojs/pdfkit/pull/1019 and https://github.com/foliojs/pdfkit/issues/369
