### PR TITLE
Fix infinite loop when lineWidth is smaller than width of a character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## pdfkit changelog
 
 ### Unreleased
+ - Fix infinite loop when an individual character is bigger than the width of the text.
  - Fix infinite loop when text is positioned after page right margin
  - Allow links in continued text to be stopped by setting link to null
 

--- a/lib/line_wrapper.js
+++ b/lib/line_wrapper.js
@@ -123,6 +123,10 @@ class LineWrapper extends EventEmitter {
             }
           }
 
+          if (l === 0 && this.spaceLeft === this.lineWidth) {
+            l = 1;
+          }
+
           // send a required break unless this is the last piece and a linebreak is not specified
           fbk.required = bk.required || l < word.length;
           shouldContinue = fn(word.slice(0, l), w, fbk, lbk);

--- a/lib/line_wrapper.js
+++ b/lib/line_wrapper.js
@@ -123,6 +123,7 @@ class LineWrapper extends EventEmitter {
             }
           }
 
+          // check for the edge case where a single character cannot fit into a line.
           if (l === 0 && this.spaceLeft === this.lineWidth) {
             l = 1;
           }

--- a/tests/unit/text.spec.js
+++ b/tests/unit/text.spec.js
@@ -15,7 +15,7 @@ describe('Text', () => {
     test('with simple content', () => {
       const docData = logData(document);
 
-      const textStream = new Buffer(
+      const textStream = Buffer.from(
         `1 0 0 -1 0 792 cm
 q
 1 0 0 -1 0 792 cm
@@ -47,7 +47,7 @@ Q
     test('with content ending after page right margin', () => {
       const docData = logData(document);
 
-      const textStream = new Buffer(
+      const textStream = Buffer.from(
         `1 0 0 -1 0 792 cm
 q
 1 0 0 -1 0 792 cm
@@ -68,6 +68,125 @@ Q
         `5 0 obj`,
         `<<
 /Length 117
+>>`,
+        `stream`,
+        textStream,
+        `\nendstream`,
+        `endobj`
+      ]);
+    });
+
+    test('with line too thin to contain a single character', () => {
+      const docData = logData(document);
+
+      const text = 'simple text';
+      const textStream = Buffer.from(
+        `1 0 0 -1 0 792 cm
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 773.384 Tm
+/F1 12 Tf
+[<73> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 759.512 Tm
+/F1 12 Tf
+[<69> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 745.64 Tm
+/F1 12 Tf
+[<6d> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 731.768 Tm
+/F1 12 Tf
+[<70> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 717.896 Tm
+/F1 12 Tf
+[<6c> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 704.024 Tm
+/F1 12 Tf
+[<65> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 690.152 Tm
+/F1 12 Tf
+[<2074> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 676.28 Tm
+/F1 12 Tf
+[<65> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 662.408 Tm
+/F1 12 Tf
+[<78> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 10 648.536 Tm
+/F1 12 Tf
+[<74> 0] TJ
+ET
+Q
+`,
+        'binary'
+      );
+
+      // before this test, this case used to make the code run into an infinite loop.
+      // To handle regresion gracefully and avoid stucking this test into an infinite loop,
+      // we look out for a side effect of this infinite loop, witch is adding and infinite number of pages.
+      // Nomaly, there should not be any page added to the document.
+
+      document.on("pageAdded", () => {
+		const pageRange = document.bufferedPageRange();
+		const newPageIndex = pageRange.start + pageRange.count;
+        // We try restrict the fail condition to only infinite loop, so we wait for several pages to be added.
+        if (newPageIndex > 10) {
+          throw new Error("Infinite loop detected");
+        }
+      });
+
+      document.text(text, 10, 10, {width: 2});
+      document.end();
+
+      expect(docData).toContainChunk([
+        `5 0 obj`,
+        `<<
+/Length 738
 >>`,
         `stream`,
         textStream,


### PR DESCRIPTION
This is a draft for a fix to issue #1018.

**What kind of change does this PR introduce?**

For now, a change to line_wrapper.

**What is the current behavior?**

When a character exceed the width of a empty line, the line wrapper keep adding new line in an infinite loop

**What is the new behavior?**

The line wrapper catch this case, and allow the character to overflow the line.

**Checklist**:

- [x] Tests (preference for unit tests)
- [x] Update CHANGELOG.md
- [x] Ready to be merged

I would like feedback on this change.

As I understand it, my check only works on empty lines, preventing change with continued text and words at the end of line with content.

Also, the way to handle this case is up for debate. Here are the different ways I tough of handling this :

- Force the insertion of the character, overflowing the width (current behavior)
- Ignore the character, losing part of the text
- throw an error
- add an option to let the user choose from all of the above

Finally, I am eager to implement new tests for this case, I just want to settle the implementation first.