### PR TITLE
Mixed corner radius values for rounded rectangles (roundedRect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Add support for mixed corner radius values for rounded rectangles
+
 ### [v0.11.0] - 2019-12-03
 
 - Fix infinite loop when an individual character is bigger than the width of the text.

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -112,20 +112,25 @@ export default {
     if (r == null) {
       r = 0;
     }
-    r = Math.min(r, 0.5 * w, 0.5 * h);
+    if (!Array.isArray(r)) {
+      r = [r, r, r, r];
+    }
 
+    // in order of: top right, bottom right, bottom left, top left
+    const [tr, br, bl, tl] = r.map(_r => Math.min(_r, 0.5 * w, 0.5 * h));
+  
     // amount to inset control points from corners (see `ellipse`)
-    const c = r * (1.0 - KAPPA);
-
-    this.moveTo(x + r, y);
-    this.lineTo(x + w - r, y);
-    this.bezierCurveTo(x + w - c, y, x + w, y + c, x + w, y + r);
-    this.lineTo(x + w, y + h - r);
-    this.bezierCurveTo(x + w, y + h - c, x + w - c, y + h, x + w - r, y + h);
-    this.lineTo(x + r, y + h);
-    this.bezierCurveTo(x + c, y + h, x, y + h - c, x, y + h - r);
-    this.lineTo(x, y + r);
-    this.bezierCurveTo(x, y + c, x + c, y, x + r, y);
+    const [ctr, cbr, cbl, ctl] = [tr, br, bl, tl].map(_r => _r * (1.0 - KAPPA));
+  
+    ctx.moveTo(x + tl, y);
+    ctx.lineTo(x + w - tr, y);
+    ctx.bezierCurveTo(x + w - ctr, y, x + w, y + ctr, x + w, y + tr);
+    ctx.lineTo(x + w, y + h - br);
+    ctx.bezierCurveTo(x + w, y + h - cbr, x + w - cbr, y + h, x + w - br, y + h);
+    ctx.lineTo(x + bl, y + h);
+    ctx.bezierCurveTo(x + cbl, y + h, x, y + h - cbl, x, y + h - bl);
+    ctx.lineTo(x, y + tl);
+    ctx.bezierCurveTo(x, y + ctl, x + ctl, y, x + tl, y);
     return this.closePath();
   },
 

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -125,15 +125,15 @@ export default {
     // amount to inset control points from corners (see `ellipse`)
     const [ctr, cbr, cbl, ctl] = [tr, br, bl, tl].map(_r => _r * (1.0 - KAPPA));
   
-    ctx.moveTo(x + tl, y);
-    ctx.lineTo(x + w - tr, y);
-    ctx.bezierCurveTo(x + w - ctr, y, x + w, y + ctr, x + w, y + tr);
-    ctx.lineTo(x + w, y + h - br);
-    ctx.bezierCurveTo(x + w, y + h - cbr, x + w - cbr, y + h, x + w - br, y + h);
-    ctx.lineTo(x + bl, y + h);
-    ctx.bezierCurveTo(x + cbl, y + h, x, y + h - cbl, x, y + h - bl);
-    ctx.lineTo(x, y + tl);
-    ctx.bezierCurveTo(x, y + ctl, x + ctl, y, x + tl, y);
+    this.moveTo(x + tl, y);
+    this.lineTo(x + w - tr, y);
+    this.bezierCurveTo(x + w - ctr, y, x + w, y + ctr, x + w, y + tr);
+    this.lineTo(x + w, y + h - br);
+    this.bezierCurveTo(x + w, y + h - cbr, x + w - cbr, y + h, x + w - br, y + h);
+    this.lineTo(x + bl, y + h);
+    this.bezierCurveTo(x + cbl, y + h, x, y + h - cbl, x, y + h - bl);
+    this.lineTo(x, y + tl);
+    this.bezierCurveTo(x, y + ctl, x + ctl, y, x + tl, y);
     return this.closePath();
   },
 

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -116,6 +116,9 @@ export default {
       r = [r, r, r, r];
     }
 
+    // set default '0' for missing indexes
+    r = [r[0] || 0, r[1] || 0, r[2] || 0, r[3] || 0];
+
     // in order of: top right, bottom right, bottom left, top left
     const [tr, br, bl, tl] = r.map(_r => Math.min(_r, 0.5 * w, 0.5 * h));
   


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

Allows option to specify mixed corner radius values for RoundedRect.

**Usage**

```
// where r: number | [topRight: number, bottomRight: number, bottomLeft: number, topLeft: number]

// all corners have a radius of 10
doc.roundedRect(x, y, w, h, 10)

// top left and bottom left corners have a radius of 10, top right and bottom right corners have no radius
doc.roundedRect(x, y, w, h, [0, 0, 10, 10])

// this is the same as doc.roundedRect(x, y, w, h, [10, 5, 0, 0])
doc.roundedRect(x, y, w, h, [10, 5])
```

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Just FYI, all jest snapshots break on my machine but are unrelated to this change (I think).