### PR TITLE
Expose LineWrapper class

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -18,6 +18,7 @@ import ImagesMixin from './mixins/images';
 import AnnotationsMixin from './mixins/annotations';
 import OutlineMixin from './mixins/outline';
 import AcroFormMixin from './mixins/acroform';
+import LineWrapper from './line_wrapper';
 
 class PDFDocument extends stream.Readable {
   constructor(options = {}) {
@@ -335,5 +336,7 @@ mixin(ImagesMixin);
 mixin(AnnotationsMixin);
 mixin(OutlineMixin);
 mixin(AcroFormMixin);
+
+PDFDocument.LineWrapper = LineWrapper;
 
 export default PDFDocument;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Exposes The `LineWrapper` class on the `PDFDocument` class as `PDFDocument.LineWrapper`

- [ ] Unit Tests  - N/A
- [ ] Documentation - N/A
- [ ] Update CHANGELOG.md - N/A
- [X] Ready to be merged 

This is so that the data driven reporting system, fluentReports, can match the line breaking of PDFKit for calculating the layout of reports.    I have finally upgraded the fluentReports engine to support the latest PDFKit and the LineWrapper used to be a separate JS file in the older versions so I could just require it and use it.  Since 0.9 this is now rolled up and internalized and no longer accessible.      
