### PR TITLE
Added `valueOf()` to info-items in `generateFileID`

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -14,7 +14,7 @@ class PDFSecurity {
       if (!info.hasOwnProperty(key)) {
         continue;
       }
-      infoStr += `${key}: ${info[key]}\n`;
+      infoStr += `${key}: ${info[key].valueOf()}\n`;
     }
 
     return wordArrayToBuffer(CryptoJS.MD5(infoStr));


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
It fixes https://github.com/foliojs/pdfkit/issues/1110 by adding `valueOf()` to the info-items accumulated in `generateFileID`.
This has no affect on the primitive items, but causes the Date object (`CreationDate`) to return a UNIX-Timestamp instead of the platform and timezone dependent date-string.

This change makes the output of `generateFileID` stable between environments.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests N/A
- [x] Documentation N/A
- [x] Update CHANGELOG.md N/A
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
One minor thing: Adding `info.CreationDate.getTime()` in line 11 seems redundant.
Should we remove that as well?