### PR TITLE
Support custom list options for label and indent

### DIFF
--- a/lib/mixins/text.js
+++ b/lib/mixins/text.js
@@ -102,10 +102,6 @@ export default {
     const unit = Math.round((this._font.ascender / 1000) * this._fontSize);
     const midLine = unit / 2;
     const r = options.bulletRadius || unit / 3;
-    const indent =
-      options.textIndent || (listType === 'bullet' ? r * 5 : unit * 2);
-    const itemIndent =
-      options.bulletIndent || (listType === 'bullet' ? r * 8 : unit * 2);
 
     let level = 1;
     const items = [];
@@ -143,6 +139,13 @@ export default {
           return `${text}.`;
       }
     };
+    
+    const getIndent = function(level) {
+      return (typeof options.customTextIndent === "function" && options.customTextIndent(level)) || options.textIndent || (listType === 'bullet' ? r * 5 : unit * 2);
+    }
+    const getItemIndent = function(level) {
+      return (typeof options.customItemIndent === "function" && options.customItemIndent(level)) || options.bulletIndent || (listType === 'bullet' ? r * 8 : unit * 2);       
+    }
 
     wrapper = new LineWrapper(this, options);
     wrapper.on('line', this._line);
@@ -152,31 +155,35 @@ export default {
     wrapper.on('firstLine', () => {
       let l;
       if ((l = levels[i++]) !== level) {
-        const diff = itemIndent * (l - level);
+        const diff = getItemIndent(level) * (l - level);
         this.x += diff;
         wrapper.lineWidth -= diff;
         level = l;
       }
 
+      if (listType !== "bullet" && typeof options.customLabel === "function") {
+        return options.customLabel(numbers[i - 1], level);
+      }
+      
       switch (listType) {
         case 'bullet':
-          this.circle(this.x - indent + r, this.y + midLine, r);
+          this.circle(this.x - getIndent(level) + r, this.y + midLine, r);
           return this.fill();
         case 'numbered':
         case 'lettered':
           var text = label(numbers[i - 1]);
-          return this._fragment(text, this.x - indent, this.y, options);
+          return this._fragment(text, this.x - getIndent(level), this.y, options);
       }
     });
 
     wrapper.on('sectionStart', () => {
-      const pos = indent + itemIndent * (level - 1);
+      const pos = getIndent(level) + getItemIndent(level) * (level - 1);
       this.x += pos;
       return (wrapper.lineWidth -= pos);
     });
 
     wrapper.on('sectionEnd', () => {
-      const pos = indent + itemIndent * (level - 1);
+      const pos = getIndent(level) + getItemIndent(level) * (level - 1);
       this.x -= pos;
       return (wrapper.lineWidth += pos);
     });


### PR DESCRIPTION
This PR enables:

A user to set custom labels (and effectively make custom list types), by accepting a `customLabel` option being a function which receives the relevant number and the level. Thereby a user can achieve a list looking something like:
(a)   First Item.
       1. Sub item
(b)   Second Item

A user to set custom indents depending on the list level, by accepting options of `customTextIndent` and `customItemIndent`.

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**


<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
