### PR TITLE
FIX AcroForm fields to call `.end()` on fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replace integration tests by visual regression tests
 - Fix access permissions in PDF version 1.7ext3
 - Fix Buffer() is deprecation warning
+- Fix _endChild() failing to end child refs without Kids prop
 
 ### [v0.11.0] - 2019-12-03
 

--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -97,8 +97,8 @@ export default {
       ref.data.Kids.forEach(childRef => {
         this._endChild(childRef);
       });
-      ref.end();
     }
+    ref.end();
     return this;
   },
 


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
Bug fix: AcroForm mixin, ._endChild() will only end the child if the child itself has `Kids` property, however the child ref should be ended regardless.

<!-- Have you done all of these things?  -->
**Checklist**:

- [ ] Unit Tests N/A
- [ ] Documentation N/A
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

There doesn't appear to be any specific test coverage of how the child elements are ended. I've left this out rather than writing a new suite of tests checking that the end method is successfully called on child elements.