### PR TITLE
Fix "@" in FontName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Replace integration tests by visual regression tests
 - Fix access permissions in PDF version 1.7ext3
 - Fix Buffer() is deprecation warning
+- Fix "@" in FontName
 
 ### [v0.11.0] - 2019-12-03
 

--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -152,9 +152,9 @@ class EmbeddedFont extends PDFFont {
       flags |= 1 << 6;
     }
 
-    // generate a tag (6 uppercase letters. 16 is the char code offset from '1' to 'A'. 74 will map to 'Z')
+    // generate a tag (6 uppercase letters. 17 is the char code offset from '0' to 'A'. 73 will map to 'Z')
     const tag = [1, 2, 3, 4, 5, 6]
-      .map(i => String.fromCharCode((this.id.charCodeAt(i) || 74) + 16))
+      .map(i => String.fromCharCode((this.id.charCodeAt(i) || 73) + 17))
       .join('');
     const name = tag + '+' + this.font.postscriptName;
 

--- a/tests/unit/font.spec.js
+++ b/tests/unit/font.spec.js
@@ -33,4 +33,23 @@ describe('EmbeddedFont', () => {
 
     expect(runSpy).toBeCalledTimes(4);
   });
+
+  describe('emebed', () => {
+    test('sets BaseName based on font id and postscript name', () => {
+      const document = new PDFDocument();
+      const font = PDFFontFactory.open(
+        document,
+        'tests/fonts/Roboto-Regular.ttf',
+        undefined,
+        'F1099'
+      );
+      const dictionary = {
+        end: () => {},
+      };
+      font.dictionary = dictionary;
+      font.embed();
+
+      expect(dictionary.data.BaseFont).toBe('A@IIZZ+Roboto-Regular');
+    });
+  });
 });

--- a/tests/unit/font.spec.js
+++ b/tests/unit/font.spec.js
@@ -49,7 +49,7 @@ describe('EmbeddedFont', () => {
       font.dictionary = dictionary;
       font.embed();
 
-      expect(dictionary.data.BaseFont).toBe('A@IIZZ+Roboto-Regular');
+      expect(dictionary.data.BaseFont).toBe('BAJJZZ+Roboto-Regular');
     });
   });
 });


### PR DESCRIPTION
#### Motivation

Adobe Illustrator fails to load fonts that have the `@` sign in FontName.

Example PDF created by PDFKit (snippet):

```
38 0 obj
<<
  /Ascent 750
  /CapHeight 720
  /Descent -250
  /Flags 4
  /FontBBox [
    -45
    -236
    1749
    997
  ]
  /FontFile2 43 0 R
  /FontName /A@ZZZZ+MetaHeadlinePro
  /ItalicAngle 0
  /StemV 0
  /Type /FontDescriptor
  /XHeight 546
>>
endobj
```

And this is how the Adobe Illustrator error message looks like:

![Untitled-e](https://user-images.githubusercontent.com/58857807/112345487-5ce6af00-8cc5-11eb-8ca0-922af7a1941d.png)

#### Problem

The problem is in `Embedded.embed()`. This function creates font name by translating numbers in the font id to letters. This works well for numbers 1-9, which get translated to `A-I`, but as soon as there is a 0 in the number, it gets translated to `@`.

#### Changes

Change `Embedded.embed()` to translate 0-9 to `A-J`.

#### Checklist

- [X] Unit Tests
- n/a Documentation -> **It's a bug fix**
- [X] Update CHANGELOG.md
- [X] Ready to be merged
