### PR TITLE
bugfix for lib/path.js svg T

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -224,8 +224,8 @@ const runners = {
     }
 
     doc.quadraticCurveTo(px, py, a[0], a[1]);
-    px = cx - (px - cx);
-    py = cy - (py - cy);
+    // px = cx - (px - cx);
+    // py = cy - (py - cy);
     cx = a[0];
     return (cy = a[1]);
   },


### PR DESCRIPTION
By commenting out lines 227,228 in lib/path.js the following SVG path is properly rendered.

d = "M 288.724 97.0955 Q 288.724 95.2205 287.299 95.2205 Q 285.499 95.2205 283.549 97.3955 T 280.324 104.071 Q 280.249 104.146 280.174 104.296 T 280.099 104.521 T 279.949 104.671 T 279.724 104.745 T 279.424 104.745 T 278.824 104.745 H 277.774 Q 277.324 104.296 277.324 104.071 Q 277.324 103.546 277.924 101.896 T 279.724 97.9955 T 283.024 94.1705 T 287.749 92.5205 Q 290.899 92.5205 292.624 94.3205 T 294.424 98.5205 Q 294.424 99.7955 294.199 100.47 Q 294.199 100.921 293.074 103.771 T 290.749 110.446 T 289.399 117.12 Q 289.399 119.146 289.774 120.421 Q 290.749 123.646 294.499 123.646 Q 297.274 123.646 299.674 121.095 T 303.424 115.171 T 305.599 108.946 T 306.424 104.821 Q 306.424 103.095 305.824 101.821 T 304.474 99.8705 T 303.124 98.5205 T 302.524 96.8705 Q 302.524 95.2205 303.949 93.7955 T 307.024 92.3705 Q 308.449 92.3705 309.574 93.7205 T 310.774 98.0705 Q 310.774 100.095 309.874 104.296 T 307.099 113.671 T 301.774 122.595 T 293.824 126.421 Q 289.024 126.421 286.174 123.946 Q 283.399 121.546 283.399 116.821 Q 283.399 114.495 283.999 112.021 T 287.074 103.245 Q 288.724 98.4455 288.724 97.0955 Z"