### PR TITLE
The doc.image() method should convert the image sizes from px to pt when drawing it.

### DIFF
--- a/lib/mixins/images.js
+++ b/lib/mixins/images.js
@@ -36,24 +36,27 @@ export default {
       this.page.xobjects[image.label] = image.obj;
     }
 
-    let w = options.width || image.width;
-    let h = options.height || image.height;
+    const imageWidth = image.width * 0.75, // convert px to pt
+      imageHeight = image.height * 0.75;
+
+    let w = options.width || imageWidth;
+    let h = options.height || imageHeight;
 
     if (options.width && !options.height) {
-      const wp = w / image.width;
-      w = image.width * wp;
-      h = image.height * wp;
+      const wp = w / imageWidth;
+      w = imageWidth * wp;
+      h = imageHeight * wp;
     } else if (options.height && !options.width) {
-      const hp = h / image.height;
-      w = image.width * hp;
-      h = image.height * hp;
+      const hp = h / imageHeight;
+      w = imageWidth * hp;
+      h = imageHeight * hp;
     } else if (options.scale) {
-      w = image.width * options.scale;
-      h = image.height * options.scale;
+      w = imageWidth * options.scale;
+      h = imageHeight * options.scale;
     } else if (options.fit) {
       [bw, bh] = options.fit;
       bp = bw / bh;
-      ip = image.width / image.height;
+      ip = imageWidth / imageHeight;
       if (ip > bp) {
         w = bw;
         h = bw / ip;
@@ -64,7 +67,7 @@ export default {
     } else if (options.cover) {
       [bw, bh] = options.cover;
       bp = bw / bh;
-      ip = image.width / image.height;
+      ip = imageWidth / imageHeight;
       if (ip > bp) {
         h = bh;
         w = bh * ip;

--- a/lib/mixins/markings.js
+++ b/lib/mixins/markings.js
@@ -135,7 +135,7 @@ export default {
     if (!this._root.data.MarkInfo) {
       this._root.data.MarkInfo = this.ref({});
     }
-    return this._root.data.Markings;
+    return this._root.data.MarkInfo;
   },
 
   getStructTreeRoot() {

--- a/lib/mixins/markings.js
+++ b/lib/mixins/markings.js
@@ -14,7 +14,8 @@ export default {
     this.structChildren = [];
 
     if (options.tagged) {
-      this.getMarkingsDictionary().data.Marked = true;
+      this.getMarkInfoDictionary().data.Marked = true;
+      this.getStructTreeRoot();
     }
   },
 
@@ -130,9 +131,9 @@ export default {
     return pageMarkings;
   },
 
-  getMarkingsDictionary() {
-    if (!this._root.data.Markings) {
-      this._root.data.Markings = this.ref({});
+  getMarkInfoDictionary() {
+    if (!this._root.data.MarkInfo) {
+      this._root.data.MarkInfo = this.ref({});
     }
     return this._root.data.Markings;
   },
@@ -153,8 +154,8 @@ export default {
   },
 
   createStructParentTreeNextKey() {
-    // initialise the Markings dictionary
-    this.getMarkingsDictionary();
+    // initialise the MarkInfo dictionary
+    this.getMarkInfoDictionary();
 
     const structTreeRoot = this.getStructTreeRoot();
     const key = structTreeRoot.data.ParentTreeNextKey++;
@@ -168,8 +169,8 @@ export default {
       structTreeRoot.end();
       this.structChildren.forEach((structElem) => structElem.end());
     }
-    if (this._root.data.Markings) {
-      this._root.data.Markings.end();
+    if (this._root.data.MarkInfo) {
+      this._root.data.MarkInfo.end();
     }
   }
 

--- a/tests/unit/markings.spec.js
+++ b/tests/unit/markings.spec.js
@@ -289,7 +289,7 @@ EMC
       ]);
       expect(docData).toContainChunk([
         `3 0 obj`,
-        /\/Markings 9 0 R/,
+        /\/MarkInfo 9 0 R/,
         `endobj`
       ]);
       expect(docData).toContainChunk([
@@ -369,7 +369,7 @@ EMC
       ]);
       expect(docData).toContainChunk([
         `3 0 obj`,
-        /\/Markings 9 0 R/,
+        /\/MarkInfo 9 0 R/,
         `endobj`
       ]);
       expect(docData).toContainChunk([
@@ -441,7 +441,7 @@ EMC
       ]);
       expect(docData).toContainChunk([
         `3 0 obj`,
-        /\/Markings 13 0 R/,
+        /\/MarkInfo 13 0 R/,
         `endobj`
       ]);
       expect(docData).toContainChunk([
@@ -569,7 +569,7 @@ EMC
       ]);
       expect(docData).toContainChunk([
         `3 0 obj`,
-        /\/Markings 5 0 R/,
+        /\/MarkInfo 5 0 R/,
         `endobj`
       ]);
       expect(docData).toContainChunk([


### PR DESCRIPTION
**What kind of change does this PR introduce?**

For example the image is 50x50 and we draw it in actual size:

```javascript
  doc.image('test.png', 0, 0);
```

and then draw a rectangle of the same size:
  
```javascript
  doc.rect(0, 0, 37.5, 37.5) // 37.5pt = 50px
     .stroke()
```

Expected: The image and the rectangle must be the same size.
Actual: The image is bigger then the rectangle.




<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
