### PR TITLE
The doc.image() method must scale image by 72/96 to automatically convert pixels to points.

### DIFF
--- a/lib/mixins/images.js
+++ b/lib/mixins/images.js
@@ -36,24 +36,27 @@ export default {
       this.page.xobjects[image.label] = image.obj;
     }
 
-    let w = options.width || image.width;
-    let h = options.height || image.height;
+    const imageWidth = image.width * 0.75, // scale by 72/ 96 to convert from pixels to points.
+      imageHeight = image.height * 0.75;
+
+    let w = options.width || imageWidth,
+      h = options.height || imageHeight;
 
     if (options.width && !options.height) {
-      const wp = w / image.width;
-      w = image.width * wp;
-      h = image.height * wp;
+      const wp = w / imageWidth;
+      w = imageWidth * wp;
+      h = imageHeight * wp;
     } else if (options.height && !options.width) {
-      const hp = h / image.height;
-      w = image.width * hp;
-      h = image.height * hp;
+      const hp = h / imageHeight;
+      w = imageWidth * hp;
+      h = imageHeight * hp;
     } else if (options.scale) {
-      w = image.width * options.scale;
-      h = image.height * options.scale;
+      w = imageWidth * options.scale;
+      h = imageHeight * options.scale;
     } else if (options.fit) {
       [bw, bh] = options.fit;
       bp = bw / bh;
-      ip = image.width / image.height;
+      ip = imageWidth / imageHeight;
       if (ip > bp) {
         w = bw;
         h = bw / ip;
@@ -64,7 +67,7 @@ export default {
     } else if (options.cover) {
       [bw, bh] = options.cover;
       bp = bw / bh;
-      ip = image.width / image.height;
+      ip = imageWidth / imageHeight;
       if (ip > bp) {
         h = bh;
         w = bh * ip;

--- a/tests/unit/image.spec.js
+++ b/tests/unit/image.spec.js
@@ -1,0 +1,41 @@
+import PDFDocument from '../../lib/document';
+import { logData } from './helpers';
+
+describe('Image', () => {
+  let document;
+
+  beforeEach(() => {
+    document = new PDFDocument({ compress: false });
+  });
+
+  test('The image must be scaled to convert pixels to points', () => {
+    const docData = logData(document),
+      image = document.openImage('tests/images/bee.jpg'),
+      scale = 72 / 96;
+
+    const stream = Buffer.from(
+      `1 0 0 -1 0 792 cm
+q
+${image.width * scale} 0 0 -${image.height * scale} 72 372 cm
+/I1 Do
+Q
+`,
+      'binary'
+    );
+
+    document.image(image);
+    document.end();
+
+    expect(docData).toContainChunk([
+      '5 0 obj',
+      `<<
+/Length 55
+>>`,
+      'stream',
+      stream,
+      '\nendstream',
+      'endobj'
+    ]);
+  });
+
+});


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

Since image sizes are specified in pixels and PDFKit uses point units, the doc.image() method must scale image by 72/96 to automatically convert pixels to points.

For example the image is 50x50 pixels and we draw it in actual size:

```javascript
  doc.image('test.png', 0, 0);
```

and then draw a rectangle of the same size over the image:
  
```javascript
  doc.rect(0, 0, 37.5, 37.5) // 37.5pt = 50px
     .stroke()
```

Expected: The image and the rectangle must be the same size.
Actual: The image is bigger then the rectangle.


<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
