### PR TITLE
Fix syntax highlighting on pdfkit.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ const stream = doc.pipe(blobStream());
 
 // add your content to the document here, as usual
 
-// get a blob when you're done
+// get a blob when you are done
 doc.end();
 stream.on('finish', function() {
   // get a blob you can do whatever you like with


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
The apostrophe in "you're" disrupts the syntax highlighting on pdfkit.org.

Syntax highlighting on github is fine.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests N/A
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This change would fix the following issue:

![image](https://user-images.githubusercontent.com/8754/136075538-f58d6ed9-08b9-44dd-9f40-edcdf0a900cf.png)
