### PR TITLE
add option to embed entire font

### DIFF
--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 import PDFFont from '../font';
 
 const toHex = function(num) {
@@ -5,15 +6,27 @@ const toHex = function(num) {
 };
 
 class EmbeddedFont extends PDFFont {
-  constructor(document, font, id) {
+  constructor(document, font, id, subset = true) {
     super();
     this.document = document;
     this.font = font;
     this.id = id;
-    this.subset = this.font.createSubset();
+
+    this.subset = subset
+    this.subsetFont = this.subset && this.font.createSubset();
     this.unicode = [[0]];
     this.widths = [this.font.getGlyph(0).advanceWidth];
 
+    if (this.subset == false) {
+      this.font.characterSet.forEach(codePoint => {
+        if (this.font.hasGlyphForCodePoint(codePoint)) {
+          const glyph = this.font.glyphForCodePoint(codePoint);
+          this.unicode[glyph.id] = [codePoint];
+          this.widths[glyph.id] = (glyph.advanceWidth * this.scale);
+        } 
+      });
+    }
+  
     this.name = this.font.postscriptName;
     this.scale = 1000 / this.font.unitsPerEm;
     this.ascender = this.font.ascent * this.scale;
@@ -100,14 +113,17 @@ class EmbeddedFont extends PDFFont {
     const res = [];
     for (let i = 0; i < glyphs.length; i++) {
       const glyph = glyphs[i];
-      const gid = this.subset.includeGlyph(glyph.id);
+      const gid = this.subset ? this.subsetFont.includeGlyph(glyph.id) : glyph.id;
+
       res.push(`0000${gid.toString(16)}`.slice(-4));
 
-      if (this.widths[gid] == null) {
-        this.widths[gid] = glyph.advanceWidth * this.scale;
-      }
-      if (this.unicode[gid] == null) {
-        this.unicode[gid] = glyph.codePoints;
+      if (this.subset) {
+        if (this.widths[gid] == null) {
+          this.widths[gid] = glyph.advanceWidth * this.scale;
+        }
+        if (this.unicode[gid] == null) {
+          this.unicode[gid] = glyph.codePoints;
+        }
       }
     }
 
@@ -121,15 +137,14 @@ class EmbeddedFont extends PDFFont {
   }
 
   embed() {
-    const isCFF = this.subset.cff != null;
+    const isCFF = (this.subsetFont || this.font).cff != null;
     const fontFile = this.document.ref();
 
     if (isCFF) {
       fontFile.data.Subtype = 'CIDFontType0C';
     }
 
-    this.subset
-      .encodeStream()
+    (this.subset ? this.font.encodeStream() : fs.createReadStream(this.font.filename))
       .on('data', data => fontFile.write(data))
       .on('end', () => fontFile.end());
 

--- a/lib/font_factory.js
+++ b/lib/font_factory.js
@@ -4,7 +4,7 @@ import StandardFont from './font/standard';
 import EmbeddedFont from './font/embedded';
 
 class PDFFontFactory {
-  static open(document, src, family, id) {
+  static open(document, src, family, id, subset = true) {
     let font;
     if (typeof src === 'string') {
       if (StandardFont.isStandardFont(src)) {
@@ -25,7 +25,7 @@ class PDFFontFactory {
       throw new Error('Not a supported font format or standard PDF font.');
     }
 
-    return new EmbeddedFont(document, font, id);
+    return new EmbeddedFont(document, font, id, subset);
   }
 }
 

--- a/lib/mixins/fonts.js
+++ b/lib/mixins/fonts.js
@@ -18,7 +18,7 @@ export default {
     }
   },
 
-  font(src, family, size) {
+  font(src, family, size, subset) {
     let cacheKey, font;
     if (typeof family === 'number') {
       size = family;
@@ -48,7 +48,7 @@ export default {
 
     // load the font
     const id = `F${++this._fontCount}`;
-    this._font = PDFFontFactory.open(this, src, family, id);
+    this._font = PDFFontFactory.open(this, src, family, id, subset);
 
     // check for existing font familes with the same name already in the PDF
     // useful if the font was passed as a buffer


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
<!-- Is it a Bug fix, feature, docs update, ... -->
feature/bug fix
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
The option to embed the entire font, to fix font issues for forms, like issue https://github.com/foliojs/pdfkit/issues/1096, if its not an standard font, on chrome it only displays glyphs included in the subset, and adobe acrobat is defaults to an opentype font.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
