### PR TITLE
Made regex quantifier lazy to resolve #381

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -16,7 +16,7 @@ class PDFImage {
       data = Buffer.from(new Uint8Array(src));
     } else {
       let match;
-      if ((match = /^data:.+;base64,(.*)$/.exec(src))) {
+      if ((match = /^data:.+?;base64,(.*)$/.exec(src))) {
         data = Buffer.from(match[1], 'base64');
       } else {
         data = fs.readFileSync(src);

--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -32,7 +32,7 @@ export default {
       data = Buffer.from(new Uint8Array(src));
     } else {
       let match;
-      if ((match = /^data:(.*);base64,(.*)$/.exec(src))) {
+      if ((match = /^data:(.*?);base64,(.*)$/.exec(src))) {
         if (match[1]) {
           refBody.Subtype = match[1].replace('/', '#2F');
         }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
As noted by #381, adding large base64-encoded images produces an error.  This happens because the file format ("image/png", "image/jpeg", etc.) is matched with the infamous `.*` pattern,  which matches the entire string (before backtracking).  This change makes it lazy. 

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
