### PR TITLE
Fix cache key collision for fonts with bad TTF metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Fix cache key collisions for fonts with bad TTF metadata
 - Add support for PDF/A-1b and PDF/A-1a
 
 ### [v0.13.0] - 2021-10-24

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,4 +1,3 @@
-
 class PDFMetadata {
     constructor() {
         this._metadata = `
@@ -7,7 +6,7 @@ class PDFMetadata {
                 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
         `;
     }
-    
+
     _closeTags() {
         this._metadata = this._metadata.concat(`
                 </rdf:RDF>
@@ -17,9 +16,9 @@ class PDFMetadata {
     }
 
     append(xml, newline=true) {
-        this._metadata = this._metadata.concat(xml); 
+        this._metadata = this._metadata.concat(xml);
         if (newline)
-            this._metadata = this._metadata.concat('\n'); 
+            this._metadata = this._metadata.concat('\n');
     }
 
     getXML() { return this._metadata; }
@@ -30,6 +29,6 @@ class PDFMetadata {
         this._closeTags();
         this._metadata = this._metadata.trim();
     }
-};
+}
 
 export default PDFMetadata;

--- a/lib/mixins/fonts.js
+++ b/lib/mixins/fonts.js
@@ -19,7 +19,7 @@ export default {
   },
 
   font(src, family, size) {
-    let cacheKey, font;
+    let name, font;
     if (typeof family === 'number') {
       size = family;
       family = null;
@@ -27,12 +27,12 @@ export default {
 
     // check registered fonts if src is a string
     if (typeof src === 'string' && this._registeredFonts[src]) {
-      cacheKey = src;
+      name = src;
       ({ src, family } = this._registeredFonts[src]);
     } else {
-      cacheKey = family || src;
-      if (typeof cacheKey !== 'string') {
-        cacheKey = null;
+      name = family || src;
+      if (typeof name !== 'string') {
+        name = null;
       }
     }
 
@@ -41,7 +41,7 @@ export default {
     }
 
     // fast path: check if the font is already in the PDF
-    if ((font = this._fontFamilies[cacheKey])) {
+    if ((font = this._fontFamilies[name])) {
       this._font = font;
       return this;
     }
@@ -50,21 +50,21 @@ export default {
     const id = `F${++this._fontCount}`;
     this._font = PDFFontFactory.open(this, src, family, id);
 
+    // get the font name from the loaded font object (usually TTF metadata)
+    // useful if the font was passed as a buffer
+    if (!name) {
+      name = this._font.name || id;
+    }
+
     // check for existing font familes with the same name already in the PDF
     // useful if the font was passed as a buffer
-    if ((font = this._fontFamilies[this._font.name])) {
+    if ((font = this._fontFamilies[name])) {
       this._font = font;
       return this;
     }
 
-    // save the font for reuse later
-    if (cacheKey) {
-      this._fontFamilies[cacheKey] = this._font;
-    }
-
-    if (this._font.name) {
-      this._fontFamilies[this._font.name] = this._font;
-    }
+    // save the font for reuse later and for finalization in doc.end()
+    this._fontFamilies[name] = this._font;
 
     return this;
   },


### PR DESCRIPTION
### Steps to reproduce

See the attached test file.

In general:

1. Have two fonts with bad `fullname` TTF metadata. For example these two both have `fullname` `"-"`:

    ```
    $ fc-query NeueHaasGrotesk-Regular.otf
    Pattern has 26 elts (size 32)
    	family: "NeueHaasGrotesk-Regular"(s)
    	familylang: "en"(s)
    	style: "Regular"(s)
    	stylelang: "en"(s)
        	fullname: "-"(s)
        	fullnamelang: "en"(s)
        	slant: 0(i)(s)
        	weight: 80(f)(s)
    	...
    $ fc-query NeueHaasGrotesk-Medium.otf 
    Pattern has 26 elts (size 32)
    	family: "NeueHaasGrotesk-Medium"(s)
    	familylang: "en"(s)
    	style: "Regular"(s)
    	stylelang: "en"(s)
    	fullname: "-"(s)
    	fullnamelang: "en"(s)
    	slant: 0(i)(s)
    	weight: 100(f)(s)
    ```

2. Use the fonts in pdfkit:

    ```js
    doc.registerFont('My Regular Font', fs.readFileSync('./NeueHaasGrotesk-Regular.otf'));
    doc.registerFont('My Medium Font', fs.readFileSync('./NeueHaasGrotesk-Medium.otf'));

    doc.font('My Regular Font');
    doc.text('Regular');

    doc.font('My Medium Font');
    doc.text('Medium');
    
    doc.font('My Regular Font');
    doc.text('Regular');
    ```

3. See that all the text is rendered with the first font:

   ![2022-08-05_11-28-17_1090x820](https://user-images.githubusercontent.com/58857807/183048891-7544b4b1-121f-4c5e-bdde-daa6494e9f9b.png)

4. Expected:

    ![2022-08-05_11-28-40_1085x818](https://user-images.githubusercontent.com/58857807/183051020-5d4322c4-7672-40ec-a19f-97ae04dfd7cb.png)

### Problem

The problem is that `doc.font()` uses the TTF `fullname` as the key in `_fontFamilies`. And because both fonts have the same `fullname`, a cache key conflict happens and `doc.font()` will always load the first font from the `_fontFamilies` cache, even when the second font is requested.

https://github.com/foliojs/pdfkit/blob/3f69586f3cb9d46cb58f255920863bbcbc5f2acd/lib/mixins/fonts.js#L53-L58

### Solution

The solution is to not use TTF `fullname` as the cache key, when there is another name available -- such as when the font has been registered.

So this solution to the bad `fullname` problem works only when the fonts are registered in advance. If we wanted to make it work without pre-registering, then we would need to somehow detect what a bad `fullname` is (e.g. check that `fullname !== '-'`), but that feels fragile. So I think requiring font registration in this case is acceptable.

### Refactoring

I've removed the following repeated setting of `_fontFamiliies` to set it only once. I couldn't think of a reason why it would need to be done twice with different cache keys:

https://github.com/foliojs/pdfkit/blob/3f69586f3cb9d46cb58f255920863bbcbc5f2acd/lib/mixins/fonts.js#L60-L67

Then since there is only one cache key now, I've renamed it to `name`.

### Unit tests

I've added some very simple unit tests. They fail like this before the change:

```
 FAIL  tests/unit/document.spec.js
  ● PDFDocument › FontsMixin › font › saves a registered font to _fontFamilies and reuses the same font object

    expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

      Array [
        "Helvetica",
        "My Roboto",
    +   "Roboto-Regular",
      ]

      83 |         const fontObj2 = doc._fontFamilies['My Roboto'];
      84 | 
    > 85 |         expect(Object.keys(doc._fontFamilies)).toEqual([
         |                                                ^
      86 |           'Helvetica',
      87 |           'My Roboto'
      88 |         ]);
```

### Checklist

- [X] Unit Tests
- [ ] Documentation
- [X] Update CHANGELOG.md
- [X] Ready to be merged