### PR TITLE
Added note to docs regarding PDF/A not supporting the standard AFM fonts

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -287,6 +287,8 @@ For PDF/A-2 and PDF/A-3, the `pdfVersion` needs to be set to at least `1.7` and 
 
 In order to verify the generated document for PDF/A and its subsets conformance, veraPDF is an excellent open source validator.
 
+Please note that PDF/A requires fonts to be embedded, as such the standard fonts PDFKit comes with cannot be used because they are in AFM format, which only provides neccessary metrics, without the font data. You should use `registerFont()` and use embeddable fonts such as `ttf`.
+
 ### Adding content
 
 Once you've created a `PDFDocument` instance, you can add content to the


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
Docs update


<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests N/A
- [x] Documentation
- [ ] Update CHANGELOG.md N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

The standard fonts that come in AFM format cannot be embedded for PDF/A support. Updated the docs to note that and suggested using `registerFont()` with ttf.
