### PR TITLE
fix missing acroform font identification

### DIFF
--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -326,7 +326,7 @@ export default {
 
   _resolveFont(options) {
     // add current font to document-level AcroForm dict if necessary
-    if (this._acroform.fonts[this._font.id] === null) {
+    if (this._acroform.fonts[this._font.id] == null) {
       this._acroform.fonts[this._font.id] = this._font.ref();
     }
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
Bug fix.

**Description**
When a font is missing in the acroform fonts dict, it is not getting added to it since a condition issue.
A key is missing means its value equals `undefined`. So that, the strict comparison to `null` is incorrect.
```js
const wrong = undefined === null; // false
const correct = undefined == null; // true
```

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests N/A
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
