### PR TITLE
Add PDF/UA subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## pdfkit changelog
 
+### Unreleased
+
+- Add subset for PDF/UA
+
 ### [v0.14.0] - 2023-11-09
 
 - Add support for PDF/A-1b, PDF/A-1a, PDF/A-2b, PDF/A-2a, PDF/A-3b, PDF/A-3a

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -14,6 +14,8 @@ Universal Accessibility) document (which is an extension of Tagged PDF):
  * Pass the option `pdfVersion: '1.5'` (or a higher version) when creating your `PDFDocument`
    (depending on the features you use, you may only need 1.4; refer to the PDF reference for
    details).
+ * Pass the option `subset: 'PDF/UA'` when creating your `PDFDocument` (if you wish the PDF to
+   be identified as PDF/UA-1).
  * Pass the option `tagged: true` when creating your `PDFDocument` (technically, this sets the
    `Marked` property in the `Markings` dictionary to `true` in the PDF).
  * Provide a `Title` in the `info` option, and pass `displayTitle: true` when creating your

--- a/lib/mixins/pdfua.js
+++ b/lib/mixins/pdfua.js
@@ -1,0 +1,24 @@
+
+export default {
+
+    initPDFUA() {
+        this.subset = 1;
+    },
+
+    endSubset() {
+        this._addPdfuaMetadata();
+    },
+
+    _addPdfuaMetadata() {
+        this.appendXML(this._getPdfuaid());
+    },
+
+    _getPdfuaid() {
+        return `
+        <rdf:Description xmlns:pdfuaid="http://www.aiim.org/pdfua/ns/id/" rdf:about="">
+            <pdfuaid:part>${this.subset}</pdfuaid:part>
+        </rdf:Description>
+        `;
+    },
+
+}

--- a/lib/mixins/subsets.js
+++ b/lib/mixins/subsets.js
@@ -1,4 +1,5 @@
 import PDFA from './pdfa';
+import PDFUA from './pdfua';
 
 export default {
     _importSubset(subset) {
@@ -19,6 +20,10 @@ export default {
             case 'PDF/A-3b':
                 this._importSubset(PDFA);
                 this.initPDFA(options.subset);
+                break;
+            case 'PDF/UA':
+                this._importSubset(PDFUA);
+                this.initPDFUA();
                 break;
         }
     }

--- a/tests/unit/pdfua.spec.js
+++ b/tests/unit/pdfua.spec.js
@@ -1,0 +1,37 @@
+import PDFDocument from '../../lib/document';
+import { logData } from './helpers';
+
+describe('PDF/UA', () => {
+
+    test('metadata is present', () => {
+        let options = {
+            autoFirstPage: false,
+            pdfVersion: '1.7',
+            subset: 'PDF/UA',
+            tagged: true
+        };
+        let doc = new PDFDocument(options);
+        const data = logData(doc);
+        doc.end();
+        expect(data).toContainChunk([
+            `11 0 obj`,
+            `<<\n/length 841\n/Type /Metadata\n/Subtype /XML\n/Length 843\n>>`
+        ]);
+    });
+
+    test('metadata constains pdfuaid part', () => {
+        let options = {
+            autoFirstPage: false,
+            pdfVersion: '1.7',
+            subset: 'PDF/UA',
+            tagged: true
+        };
+        let doc = new PDFDocument(options);
+        const data = logData(doc);
+        doc.end();
+        let metadata = Buffer.from(data[24]).toString();
+
+        expect(metadata).toContain('pdfuaid:part>1');
+    });
+
+});


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

Improves existing PDF/UA compliance by allowing users to use `subset: 'PDF/UA'` when creating the `PDFDocument` which will result PDF/UA to be added to the created PDF metadata.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Documentation
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Currently we're implementing PDF/UA compliance and are going through a checklist of requirements we must meet in order to generare valid PDF/UA PDFs.

One of the first requirements we haven't been able to meet is a missing PDF/UA identifier from the PDF's metadata.

With this change, the checks seems to pass (using [PAC 2021 - PDF Accessibility Checker](https://pdfua.foundation/en/pdf-accessibility-checker-pac/) for testing compliance).