### PR TITLE
Prevent adding identity transforms to the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add subset for PDF/UA
 - Fix for line breaks in list items (#1486)
 - Fix for soft hyphen not being replaced by visible hyphen if necessary (#457)
+- Optimize output files by ignoring identity transforms
 
 ### [v0.14.0] - 2023-11-09
 

--- a/lib/mixins/vector.js
+++ b/lib/mixins/vector.js
@@ -289,6 +289,10 @@ export default {
 
   transform(m11, m12, m21, m22, dx, dy) {
     // keep track of the current transformation matrix
+    if (m11 === 1 && m12 === 0 && m21 === 0 && m22 === 1 && dx === 0 && dy === 0) {
+      // Ignore identity transforms
+      return this;
+    }
     const m = this._ctm;
     const [m0, m1, m2, m3, m4, m5] = m;
     m[0] = m0 * m11 + m2 * m12;

--- a/tests/unit/vector.spec.js
+++ b/tests/unit/vector.spec.js
@@ -164,4 +164,26 @@ describe('Vector Graphics', () => {
       });
     });
   });
+
+  describe('translate', () => {
+    test('identity transform is ignored', () => {
+      const docData = logData(document);
+      const vectorStream = Buffer.from(`1 0 0 -1 0 792 cm\n1 0 0 1 0 0 cm\n`, 'binary');
+
+      document
+        .translate(0, 0);
+      document.end();
+
+      expect(docData).not.toContainChunk([
+        `5 0 obj`,
+        `<<
+/Length 33
+>>`,
+        `stream`,
+        vectorStream,
+        `\nendstream`,
+        `endobj`
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

This makes the resulting PDF files smaller. It's cumbersome to filter out all commands that could result in identity transforms in code that's using PDFKit, so it makes sense to have the check in the transform() function.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation N/A
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This change is sponsored by [Higharc](https://higharc.com).
