### PR TITLE
Fix Acroforms - setting an option to false will still apply the flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix for line breaks in list items (#1486)
 - Fix for soft hyphen not being replaced by visible hyphen if necessary (#457)
 - Optimize output files by ignoring identity transforms
+- Fix for Acroforms - setting an option to false will still apply the flag (#1495)
 
 ### [v0.14.0] - 2023-11-09
 

--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -298,7 +298,7 @@ export default {
   _resolveFlags(options) {
     let result = 0;
     Object.keys(options).forEach(key => {
-      if (FIELD_FLAGS[key]) {
+      if (FIELD_FLAGS[key] && !!options[key]) {
         result |= FIELD_FLAGS[key];
         delete options[key];
       }

--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -298,8 +298,10 @@ export default {
   _resolveFlags(options) {
     let result = 0;
     Object.keys(options).forEach(key => {
-      if (FIELD_FLAGS[key] && !!options[key]) {
-        result |= FIELD_FLAGS[key];
+      if (FIELD_FLAGS[key]) {
+        if (options[key]) {
+          result |= FIELD_FLAGS[key];
+        }
         delete options[key];
       }
     });

--- a/tests/unit/acroform.spec.js
+++ b/tests/unit/acroform.spec.js
@@ -212,6 +212,33 @@ describe('acroform', () => {
     expect(docData).toContainChunk(expected);
   });
 
+  test('false flags should be ignored', () => {
+    const expectedDoc = new PDFDocument({
+      info: { CreationDate: new Date(Date.UTC(2018, 1, 1)) }
+    });
+    expectedDoc.initForm();
+    const expectedDocData = logData(expectedDoc);
+    let emptyOpts = {
+      align: 'center'
+    };
+    expectedDoc.formText('flags', 20, 20, 50, 20, emptyOpts);
+
+    doc.initForm();
+    const docData = logData(doc);
+    let opts = {
+      required: false,
+      noExport: false,
+      readOnly: false,
+      align: 'center',
+      multiline: false,
+      password: false,
+      noSpell: false
+    };
+    doc.formText('flags', 20, 20, 50, 20, opts);
+
+    expect(docData).toContainChunk(expectedDocData);
+  });
+
   test('font size', () => {
     const expected = [
       '11 0 obj',


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
This PR fixes #1495 (Acroforms - setting an option to false will still apply the flag).

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation - N/A
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
