### PR TITLE
Bugfix: File Cache Equality Check Incorrectly Compares Dates

### DIFF
--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -105,11 +105,13 @@ export default {
 
 /** check two embedded file metadata objects for equality */
 function isEqual(a, b) {
-  return (
+  const result = (
     a.Subtype === b.Subtype &&
     a.Params.CheckSum.toString() === b.Params.CheckSum.toString() &&
     a.Params.Size === b.Params.Size &&
-    a.Params.CreationDate === b.Params.CreationDate &&
-    a.Params.ModDate === b.Params.ModDate
+    a.Params.CreationDate.toISOString() === b.Params.CreationDate.toISOString() &&
+    a.Params.ModDate.toISOString() === b.Params.ModDate.toISOString()
   );
+  console.log('isEqual', result);
+  return result;
 }

--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -105,13 +105,11 @@ export default {
 
 /** check two embedded file metadata objects for equality */
 function isEqual(a, b) {
-  const result = (
+  return (
     a.Subtype === b.Subtype &&
     a.Params.CheckSum.toString() === b.Params.CheckSum.toString() &&
     a.Params.Size === b.Params.Size &&
-    a.Params.CreationDate.toISOString() === b.Params.CreationDate.toISOString() &&
-    a.Params.ModDate.toISOString() === b.Params.ModDate.toISOString()
+    a.Params.CreationDate.getTime() === b.Params.CreationDate.getTime() &&
+    a.Params.ModDate.getTime() === b.Params.ModDate.getTime()
   );
-  console.log('isEqual', result);
-  return result;
 }

--- a/tests/unit/attachments.spec.js
+++ b/tests/unit/attachments.spec.js
@@ -166,7 +166,6 @@ describe('file', () => {
 
   test('attach multiple files', () => {
     const docData = logData(document);
-    const duplicateDate = new Date(date)
 
     document.file(Buffer.from('example text'), {
       name: 'file1.txt',

--- a/tests/unit/attachments.spec.js
+++ b/tests/unit/attachments.spec.js
@@ -166,6 +166,7 @@ describe('file', () => {
 
   test('attach multiple files', () => {
     const docData = logData(document);
+    const duplicateDate = new Date(date)
 
     document.file(Buffer.from('example text'), {
       name: 'file1.txt',
@@ -190,6 +191,41 @@ describe('file', () => {
   /Names [
     (file1.txt) 9 0 R
     (file2.txt) 11 0 R
+]
+>>
+>>`
+    ]);
+  });
+
+  test('attach the same file multiple times', () => {
+    const docData = logData(document);
+
+    document.file(Buffer.from('example text'), {
+      name: 'file1.txt',
+      creationDate: date,
+      modifiedDate: date
+    });
+    document.file(Buffer.from('example text'), {
+      name: 'file1.txt',
+      creationDate: new Date(date),
+      modifiedDate: new Date(date)
+    });
+    document.end();
+
+    const numFiles = docData.filter((str) => typeof str === 'string' && str.startsWith('<<\n/Type /EmbeddedFile\n'))
+    
+    expect(numFiles.length).toEqual(1)
+    
+    expect(docData).toContainChunk([
+      `2 0 obj`,
+      `<<
+/Dests <<
+  /Names [
+]
+>>
+/EmbeddedFiles <<
+  /Names [
+    (file1.txt) 10 0 R
 ]
 >>
 >>`


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
The change fixes a bug in how file equality is checked which leads to bloated pdf sizes; in particular, the dates for when a file was modified or created are checked for reference equality rather than by comparing whether the date objects represent the same date.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
