### PR TITLE
fix: pdf/a compliance of attachments

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -24,6 +24,7 @@ There are a few other options for `doc.file`:
 * `hidden` - if true, do not show file in the list of embedded files
 * `creationDate` - override the date and time the file was created
 * `modifiedDate` - override the date and time the file was last updated
+* `relationship` - relationship between the PDF document and its attached file. Can be 'Alternative', 'Data', 'Source', 'Supplement' or 'Unspecified'.
 
 If you are attaching a file from your file system, creationDate and modifiedDate will be set to the source file's creationDate and modifiedDate.
 

--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -12,10 +12,12 @@ export default {
    *  * options.hidden: if true, do not add attachment to EmbeddedFiles dictionary. Useful for file attachment annotations
    *  * options.creationDate: override creation date
    *  * options.modifiedDate: override modified date
+   *  * options.relationship: Relationship between the PDF document and its attached file. Can be 'Alternative', 'Data', 'Source', 'Supplement' or 'Unspecified'.
    * @returns filespec reference
    */
   file(src, options = {}) {
     options.name = options.name || src;
+    options.relationship = options.relationship || 'Unspecified';
 
     const refBody = {
       Type: 'EmbeddedFile',
@@ -85,6 +87,7 @@ export default {
     // add filespec for embedded file
     const fileSpecBody = {
       Type: 'Filespec',
+      AFRelationship: options.relationship,
       F: new String(options.name),
       EF: { F: ref },
       UF: new String(options.name)
@@ -97,6 +100,13 @@ export default {
 
     if (!options.hidden) {
       this.addNamedEmbeddedFile(options.name, filespec);
+    }
+
+    // Add file to the catalogue to be PDF/A3 compliant
+    if (this._root.data.AF) {
+      this._root.data.AF.push(filespec);
+    } else {
+      this._root.data.AF = [filespec];
     }
 
     return filespec;

--- a/tests/unit/attachments.spec.js
+++ b/tests/unit/attachments.spec.js
@@ -54,6 +54,7 @@ describe('file', () => {
       `9 0 obj`,
       `<<
 /Type /Filespec
+/AFRelationship /Unspecified
 /F (file.txt)
 /EF <<
 /F 8 0 R
@@ -112,6 +113,7 @@ describe('file', () => {
       `9 0 obj`,
       `<<
 /Type /Filespec
+/AFRelationship /Unspecified
 /F (file.txt)
 /EF <<
 /F 8 0 R


### PR DESCRIPTION
Fixes part of #1561 

I followed the contributing guide, but this did not work. All tests failed due to some jest config problem:

```
Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.
```

Is the contributing guide up-to-date? 