### PR TITLE
fix: skip CIDSet generation for PDF/A3 subset

### DIFF
--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -183,7 +183,7 @@ class EmbeddedFont extends PDFFont {
       descriptor.data.FontFile2 = fontFile;
     }
 
-    if (this.document.subset) {
+    if (this.document.subset && this.document.subset < 3) {
       const CIDSet = Buffer.from('FFFFFFFFC0', 'hex');
       const CIDSetRef = this.document.ref();
       CIDSetRef.write(CIDSet);
@@ -258,7 +258,11 @@ class EmbeddedFont extends PDFFont {
     for (let i = 0; i < chunks; i++) {
       const start = i * chunkSize;
       const end = Math.min((i + 1) * chunkSize, entries.length);
-      ranges.push(`<${toHex(start)}> <${toHex(end - 1)}> [${entries.slice(start, end).join(' ')}]`);
+      ranges.push(
+        `<${toHex(start)}> <${toHex(end - 1)}> [${entries
+          .slice(start, end)
+          .join(' ')}]`
+      );
     }
 
     cmap.end(`\


### PR DESCRIPTION
Fixes the second part of #1561. CIDSet is only generated for PDF/A subsets 1 and 2 (not 100% sure if it could be skipped for 2 as well).

I followed the contributing guide, but this did not work. All tests failed due to some jest config problem:

```
Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.
```

Is the contributing guide up-to-date? 