### PR TITLE
Fix precision rounding issues in LineWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## pdfkit changelog
 
+### Unreleased
+
+- Fix precision rounding issues in LineWrapper
+
 ### [v0.16.0] - 2024-12-29
 
 - Update fontkit to 2.0

--- a/lib/line_wrapper.js
+++ b/lib/line_wrapper.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import LineBreaker from 'linebreak';
+import { PDFNumber } from './utils';
 
 const SOFT_HYPHEN = '\u00AD';
 const HYPHEN = '-';
@@ -26,9 +27,9 @@ class LineWrapper extends EventEmitter {
     // calculate the maximum Y position the text can appear at
     if (options.height != null) {
       this.height = options.height;
-      this.maxY = this.startY + options.height;
+      this.maxY = PDFNumber(this.startY + options.height);
     } else {
-      this.maxY = this.document.page.maxY();
+      this.maxY = PDFNumber(this.document.page.maxY());
     }
 
     // handle paragraph indents
@@ -230,7 +231,7 @@ class LineWrapper extends EventEmitter {
         if (
           this.height != null &&
           this.ellipsis &&
-          this.document.y + lh * 2 > this.maxY &&
+          PDFNumber(this.document.y + lh * 2) > this.maxY &&
           this.column >= this.columns
         ) {
           if (this.ellipsis === true) {
@@ -274,7 +275,7 @@ class LineWrapper extends EventEmitter {
 
         // if we've reached the edge of the page,
         // continue on a new page or column
-        if (this.document.y + lh > this.maxY) {
+        if (PDFNumber(this.document.y + lh) > this.maxY) {
           const shouldContinue = this.nextSection();
 
           // stop if we reached the maximum height

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,6 @@
+export function PDFNumber(n) {
+  // PDF numbers are strictly 32bit
+  // so convert this number to the nearest 32bit number
+  // @see ISO 32000-1 Annex C.2 (real numbers)
+  return Math.fround(n);
+}

--- a/tests/unit/line_wrapper.spec.js
+++ b/tests/unit/line_wrapper.spec.js
@@ -1,0 +1,62 @@
+import PDFDocument from "../../lib/document";
+import LineWrapper from '../../lib/line_wrapper';
+
+describe("LineWrapper", () => {
+  let document;
+
+  beforeEach(() => {
+    document = new PDFDocument({
+      compress: false,
+      margin: 0,
+    });
+  });
+
+  test("ellipsis is present only on last line of multiline text", () => {
+    // There is a weird edge case where ellipsis occurs on lines
+    // in the middle of text due to number rounding errors
+    //
+    // There is probably a simpler combination of values but this is one I found in the wild
+    document.y = 402.1999999999999;
+    document.fontSize(7.26643598615917)
+    const wrapper = new LineWrapper(document, {width: 300, height: 50.399999999999864, ellipsis: true})
+    let wrapperOutput = "";
+    wrapper.on("line", (buffer) => {
+      wrapperOutput += buffer;
+      document.y += document.currentLineHeight(true)
+    })
+    wrapper.wrap("- A\n- B\n- C\n- D\n- E\n- F", {})
+    expect(wrapperOutput).toBe("- A\n- B\n- C\n- D\n- E\n- F");
+  })
+
+  test("line break is handled correctly when at weird heights", () => {
+    // There is probably a simpler combination of values but this is one I found in the wild
+    document.y = 1/3;
+    document.fontSize(Math.fround(42.3/3));
+    let lineHeight = document.currentLineHeight(true);
+    const wrapper = new LineWrapper(document, {width: 300, height:lineHeight*3})
+    let wrapperOutput = "";
+    wrapper.on("line", (buffer) => {
+      wrapperOutput += buffer;
+      document.y += lineHeight
+    })
+    // Limit to 3/4 lines
+    wrapper.wrap("A\nB\nC\nD", {})
+    expect(wrapperOutput).toBe("A\nB\nC\n");
+  });
+
+  test("line break is handled correctly with ellipsis", () => {
+    // There is probably a simpler combination of values but this is one I found in the wild
+    document.y = 1/3;
+    document.fontSize(Math.fround(42.3/3));
+    let lineHeight = document.currentLineHeight(true);
+    const wrapper = new LineWrapper(document, {width: 300, height:lineHeight*3, ellipsis: true})
+    let wrapperOutput = "";
+    wrapper.on("line", (buffer) => {
+      wrapperOutput += buffer;
+      document.y += lineHeight
+    })
+    // Limit to 3/4 lines
+    wrapper.wrap("A\nB\nC\nD", {})
+    expect(wrapperOutput).toBe("A\nB\nC…");
+  });
+});


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

Handle JS quirks with large decimal precision checks resulting from the calculations of next lines in the LineWrapper

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation N/A
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Yes this is a very niche situation but it has caused many headaches for me when working with very precise measurements and/or weird font sizes