### PR TITLE
Fix side normalize when non-object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ export function PDFNumber(n) {
  * - Or `{top: SideValue, right: SideValue, bottom: SideValue, left: SideValue}`
  *
  * @template T
- * @typedef {T | [T, T] | [T, T, T, T] | { vertical: T; horizontal: T } | { top: T; right: T; bottom: T; left: T }} SideDefinition<T>
+ * @typedef {T | [T, T] | [T, T, T, T] | { vertical: T; horizontal: T } | ExpandedSideDefinition<T>} SideDefinition<T>
  **/
 
 /**
@@ -52,12 +52,13 @@ export function normalizeSides(
   transformer = (v) => v,
 ) {
   if (
-    sides === undefined || sides === null ||
+    sides === undefined ||
+    sides === null ||
     (typeof sides === "object" && Object.keys(sides).length === 0)
   ) {
     sides = defaultDefinition;
   }
-  if (typeof sides === "string" || typeof sides === "number" || !sides) {
+  if (typeof sides !== "object" || sides === null) {
     sides = [sides, sides, sides, sides];
   }
   if (Array.isArray(sides)) {

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -33,6 +33,14 @@ describe("normalizeSides", () => {
       undefined,
       { top: undefined, right: undefined, bottom: undefined, left: undefined },
     ],
+    [
+      true,
+      { top: true, right: true, bottom: true, left: true },
+    ],
+    [
+      false,
+      { top: false, right: false, bottom: false, left: false },
+    ],
   ])("%s -> %s", (size, expected) => {
     expect(normalizeSides(size)).toEqual(expected);
   });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

Fix error which occurs when `normalizeSides` is called with a non-object non-string/number e.g. a boolean.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md N/A (will be part of the dynamic sizing feature (#1576)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
