### PR TITLE
Fix page cascade options when text overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix fonts without a postscriptName
 - Add support for dynamic sizing
 - Add support for rotatable text
+- Fix page cascade options when text overflows
 
 ### [v0.16.0] - 2024-12-29
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -169,7 +169,7 @@ class PDFDocument extends stream.Readable {
   continueOnNewPage(options) {
     const pageMarkings = this.endPageMarkings(this.page);
 
-    this.addPage(options);
+    this.addPage(options ?? this.page._options);
 
     this.initPageMarkings(pageMarkings);
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -71,6 +71,7 @@ const SIZES = {
 class PDFPage {
   constructor(document, options = {}) {
     this.document = document;
+    this._options = options;
     this.size = options.size || 'letter';
     this.layout = options.layout || 'portrait';
 

--- a/tests/unit/page.spec.js
+++ b/tests/unit/page.spec.js
@@ -1,0 +1,16 @@
+import PDFDocument from '../../lib/document';
+
+describe('page', function () {
+  test('cascade page options', function () {
+    const doc = new PDFDocument({
+      autoFirstPage: false,
+      bufferPages: true,
+    });
+    doc.addPage({ size: [50, 50], margin: 0 });
+    doc.text(Array(10).fill('TEST').join('\n'));
+    doc._pageBuffer.forEach((page) => {
+      expect(page.size).toEqual([50, 50]);
+      expect(page.margins).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**

When text overflows onto a new page and the page is created, any new pages it makes are defined using the default document page options rather than the current page.

This fixes that by forcing `continueOnNewPage` to inherit the current page options.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation (N/A)
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
