### PR TITLE
fixed png images rendering issues for qrcode

### DIFF
--- a/lib/image/png.js
+++ b/lib/image/png.js
@@ -103,7 +103,7 @@ class PNGImage {
         Subtype: 'Image',
         Height: this.height,
         Width: this.width,
-        BitsPerComponent: 8,
+        BitsPerComponent: this.image.hasAlphaChannel ? 8 : this.image.bits,
         Filter: 'FlateDecode',
         ColorSpace: 'DeviceGray',
         Decode: [0, 1],


### PR DESCRIPTION
Fixed the issue [https://github.com/foliojs/pdfkit/issues/1638](https://github.com/foliojs/pdfkit/issues/1638)


**Before:**
<img width="526" height="110" alt="image" src="https://github.com/user-attachments/assets/889c76e1-050e-4cf6-b726-37235bd5c558" />

**Result:**
<img width="526" height="110" alt="image" src="https://github.com/user-attachments/assets/30b64d02-bd90-40f0-9b44-131d419ddbc3" />