### PR TITLE
Add support for rgb values in spot color

### DIFF
--- a/lib/spotcolor.js
+++ b/lib/spotcolor.js
@@ -1,22 +1,37 @@
 export default class SpotColor {
   constructor(doc, name, C, M, Y, K) {
-    this.id = 'CS' + Object.keys(doc.spotColors).length;
-    this.name = name;
-    this.values = [C, M, Y, K];
-    this.ref = doc.ref([
-      'Separation',
-      this.name,
-      'DeviceCMYK',
-      {
-        Range: [0, 1, 0, 1, 0, 1, 0, 1],
-        C0: [0, 0, 0, 0],
-        C1: this.values.map((value) => value / 100),
+    if (typeof K === "undefined") {
+      this.id = 'CS' + Object.keys(doc.spotColors).length;
+      this.name = name;
+      this.values = [C, M, Y];
+      this.ref = doc.ref(['Separation', this.name, 'DeviceRGB', {
+        Range: [0, 1, 0, 1, 0, 1],
+        C0: [0, 0, 0],
+        C1: this.values.map(value => value / 255),
         FunctionType: 2,
         Domain: [0, 1],
-        N: 1,
-      },
-    ]);
-    this.ref.end();
+        N: 1
+      }]);
+      this.ref.end();
+    } else {
+      this.id = 'CS' + Object.keys(doc.spotColors).length;
+      this.name = name;
+      this.values = [C, M, Y, K];
+      this.ref = doc.ref([
+        'Separation',
+        this.name,
+        'DeviceCMYK',
+        {
+          Range: [0, 1, 0, 1, 0, 1, 0, 1],
+          C0: [0, 0, 0, 0],
+          C1: this.values.map((value) => value / 100),
+          FunctionType: 2,
+          Domain: [0, 1],
+          N: 1,
+        },
+      ]);
+      this.ref.end();
+    }
   }
 
   toString() {

--- a/tests/unit/color.spec.js
+++ b/tests/unit/color.spec.js
@@ -56,4 +56,25 @@ describe('color', function () {
         '>>',
     ]);
   });
+
+  test('spot color with rgb', function () {
+    const doc = new PDFDocument();
+    const data = logData(doc);
+    doc.addSpotColor('MAGENTA', 255, 0, 255);
+    doc.fillColor('MAGENTA').text('This text uses spot color!');
+    doc.end();
+
+    expect(data).toContainChunk([
+      `6 0 obj`,
+      '<<\n' +
+        '/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]\n' +
+        '/ColorSpace <<\n' +
+        '/CS0 8 0 R\n' +
+        '>>\n' +
+        '/Font <<\n' +
+        '/F1 9 0 R\n' +
+        '>>\n' +
+        '>>',
+    ]);
+  });
 });


### PR DESCRIPTION

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
It adds support to add a spot color with rgb values instead of cmyk values.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation N/A
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Let me know if there is a more elegant way of adding support for this. I didn't want to change the API more than necessary.