### PR TITLE
Set checkbox/radio values correctly

### DIFF
--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -373,11 +373,13 @@ export default {
         delete options[key];
       }
     });
-    ['V', 'DV'].forEach((key) => {
-      if (typeof options[key] === 'string') {
-        options[key] = new String(options[key]);
-      }
-    });
+    if (options.FT !== 'Btn') {
+      ['V', 'DV'].forEach((key) => {
+        if (typeof options[key] === 'string') {
+          options[key] = new String(options[key]);
+        }
+      });
+    }
 
     if (options.MK && options.MK.CA) {
       options.MK.CA = new String(options.MK.CA);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
Allows a solution for #1397 

**What kind of change does this PR introduce?**
Fixes an bug where a slash is not added to the user-provided value or default value of a button field (checkbox or radio), for instance making its value `Yes` instead of `/Yes`. This prevents it from displaying or functioning correctly in some readers. Even if the user sets the value to `/Yes`, it appears to be set as a String and not a Name, causing the same issue.

This PR ensures that the value and default value is set to a Name beginning with a slash.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->