### PR TITLE
fix: escaping PDF Object Names (space in spot color name fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix PDF/UA compliance issues in kitchen-sink-accessible example
 - Add bbox and placement options to PDFStructureElement for PDF/UA compliance
 - Extend `roundedRect` with `borderRadius` as number for all corners or per-corner array (CSS order)
+- Fix PDF Name escaping for spot colors with spaces ([#1644](https://github.com/foliojs/pdfkit/issues/1644))
 
 ### [v0.18.0] - 2026-03-14
 

--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -36,7 +36,7 @@ export default {
       const match = /^data:(.*?);base64,(.*)$/.exec(src);
       if (match) {
         if (match[1]) {
-          refBody.Subtype = match[1].replace('/', '#2F');
+          refBody.Subtype = match[1];
         }
         data = Buffer.from(match[2], 'base64');
       } else {
@@ -61,7 +61,7 @@ export default {
     }
     // add optional subtype
     if (options.type) {
-      refBody.Subtype = options.type.replace('/', '#2F');
+      refBody.Subtype = options.type;
     }
 
     // add checksum and size information

--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { md5Hex } from '../crypto/md5';
+import { escapeName } from '../object.js';
 
 export default {
   /**
@@ -36,7 +37,7 @@ export default {
       const match = /^data:(.*?);base64,(.*)$/.exec(src);
       if (match) {
         if (match[1]) {
-          refBody.Subtype = match[1];
+          refBody.Subtype = escapeName(match[1]);
         }
         data = Buffer.from(match[2], 'base64');
       } else {
@@ -61,7 +62,7 @@ export default {
     }
     // add optional subtype
     if (options.type) {
-      refBody.Subtype = options.type;
+      refBody.Subtype = escapeName(options.type);
     }
 
     // add checksum and size information

--- a/lib/object.js
+++ b/lib/object.js
@@ -9,6 +9,29 @@ import SpotColor from './spotcolor';
 
 const pad = (str, length) => (Array(length + 1).join('0') + str).slice(-length);
 
+// PDF Name objects must escape delimiter characters and whitespace. We keep
+// non-ASCII characters unescaped for backward compatibility in existing output.
+const isSafeNameChar = (char) => {
+  const code = char.charCodeAt(0);
+  if (code > 0x7f) return true; // keep non-ASCII characters as-is
+
+  return (
+    code > 0x20 && // exclude NUL/control chars + space (0x00-0x20)
+    code !== 0x7f && // exclude DEL
+    char !== '#' && // # (escape marker)
+    char !== '%' && // % (comment introducer)
+    char !== '(' &&
+    char !== ')' &&
+    char !== '/' &&
+    char !== '<' &&
+    char !== '>' &&
+    char !== '[' &&
+    char !== ']' &&
+    char !== '{' &&
+    char !== '}'
+  );
+};
+
 const escapableRe = /[\n\r\t\b\f()\\]/g;
 const escapable = {
   '\n': '\\n',
@@ -38,10 +61,25 @@ const swapBytes = function (buff) {
 };
 
 class PDFObject {
+  static escapeName(value) {
+    let escapedName = '';
+
+    for (const char of value) {
+      if (isSafeNameChar(char)) {
+        escapedName += char;
+      } else {
+        const code = char.charCodeAt(0);
+        escapedName += `#${code.toString(16).toUpperCase().padStart(2, '0')}`;
+      }
+    }
+
+    return escapedName;
+  }
+
   static convert(object, encryptFn = null) {
     // String literals are converted to the PDF name type
     if (typeof object === 'string') {
-      return `/${object}`;
+      return `/${PDFObject.escapeName(object)}`;
 
       // String objects are converted to PDF strings (UTF-16)
     } else if (object instanceof String) {
@@ -112,7 +150,9 @@ class PDFObject {
       const out = ['<<'];
       for (let key in object) {
         const val = object[key];
-        out.push(`/${key} ${PDFObject.convert(val, encryptFn)}`);
+        out.push(
+          `/${PDFObject.escapeName(key)} ${PDFObject.convert(val, encryptFn)}`,
+        );
       }
 
       out.push('>>');

--- a/lib/object.js
+++ b/lib/object.js
@@ -11,24 +11,23 @@ const pad = (str, length) => (Array(length + 1).join('0') + str).slice(-length);
 
 // PDF Name objects must escape delimiter characters and whitespace. We keep
 // non-ASCII characters unescaped for backward compatibility in existing output.
-const isSafeNameChar = (char) => {
-  const code = char.charCodeAt(0);
+const isSafeCharCode = (code) => {
   if (code > 0x7f) return true; // keep non-ASCII characters as-is
 
   return (
     code > 0x20 && // exclude NUL/control chars + space (0x00-0x20)
     code !== 0x7f && // exclude DEL
-    char !== '#' && // # (escape marker)
-    char !== '%' && // % (comment introducer)
-    char !== '(' &&
-    char !== ')' &&
-    char !== '/' &&
-    char !== '<' &&
-    char !== '>' &&
-    char !== '[' &&
-    char !== ']' &&
-    char !== '{' &&
-    char !== '}'
+    code !== 0x23 && // # (escape marker)
+    code !== 0x25 && // % (comment introducer)
+    code !== 0x28 && // ( (literal string delimiter)
+    code !== 0x29 && // ) (literal string delimiter)
+    code !== 0x2f && // / (name object delimiter)
+    code !== 0x3c && // < (hex string delimiter)
+    code !== 0x3e && // > (hex string delimiter)
+    code !== 0x5b && // [ (array start)
+    code !== 0x5d && // ] (array end)
+    code !== 0x7b && // { (dictionary start)
+    code !== 0x7d // } (dictionary end)
   );
 };
 
@@ -42,6 +41,21 @@ const escapable = {
   '\\': '\\\\',
   '(': '\\(',
   ')': '\\)',
+};
+
+export const escapeName = function (name) {
+  let escapedName = '';
+
+  for (const char of name) {
+    const code = char.charCodeAt(0);
+    if (isSafeCharCode(code)) {
+      escapedName += char;
+    } else {
+      escapedName += `#${code.toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+  }
+
+  return escapedName;
 };
 
 // Convert little endian UTF-16 to big endian
@@ -61,25 +75,10 @@ const swapBytes = function (buff) {
 };
 
 class PDFObject {
-  static escapeName(value) {
-    let escapedName = '';
-
-    for (const char of value) {
-      if (isSafeNameChar(char)) {
-        escapedName += char;
-      } else {
-        const code = char.charCodeAt(0);
-        escapedName += `#${code.toString(16).toUpperCase().padStart(2, '0')}`;
-      }
-    }
-
-    return escapedName;
-  }
-
   static convert(object, encryptFn = null) {
     // String literals are converted to the PDF name type
     if (typeof object === 'string') {
-      return `/${PDFObject.escapeName(object)}`;
+      return `/${object}`;
 
       // String objects are converted to PDF strings (UTF-16)
     } else if (object instanceof String) {
@@ -150,9 +149,7 @@ class PDFObject {
       const out = ['<<'];
       for (let key in object) {
         const val = object[key];
-        out.push(
-          `/${PDFObject.escapeName(key)} ${PDFObject.convert(val, encryptFn)}`,
-        );
+        out.push(`/${key} ${PDFObject.convert(val, encryptFn)}`);
       }
 
       out.push('>>');

--- a/lib/spotcolor.js
+++ b/lib/spotcolor.js
@@ -1,3 +1,5 @@
+import { escapeName } from './object.js';
+
 export default class SpotColor {
   constructor(doc, name, C, M, Y, K) {
     this.id = 'CS' + Object.keys(doc.spotColors).length;
@@ -5,7 +7,7 @@ export default class SpotColor {
     this.values = [C, M, Y, K];
     this.ref = doc.ref([
       'Separation',
-      this.name,
+      escapeName(this.name),
       'DeviceCMYK',
       {
         Range: [0, 1, 0, 1, 0, 1, 0, 1],

--- a/tests/unit/attachments.spec.js
+++ b/tests/unit/attachments.spec.js
@@ -120,6 +120,21 @@ describe('file', () => {
     ]);
   });
 
+  test('uses data URI MIME type as escaped subtype', () => {
+    const docData = logData(document);
+    document.file('data:text/plain;base64,ZXhhbXBsZSB0ZXh0', {
+      name: 'file.txt',
+      creationDate: date,
+      modifiedDate: date,
+    });
+    document.end();
+
+    const dataStr = docData.map((item) => item.toString()).join('\n');
+    expect(dataStr).toContain('/Subtype /text#2Fplain');
+    expect(dataStr).not.toContain('/Subtype /text/plain');
+    expect(dataStr).not.toContain('/Subtype /text#232Fplain'); // double escaped
+  });
+
   test('with hidden option', () => {
     const docData = logData(document);
 

--- a/tests/unit/color.spec.js
+++ b/tests/unit/color.spec.js
@@ -56,4 +56,24 @@ describe('color', function () {
         '>>',
     ]);
   });
+
+  test('spot color escapes color name in Separation color space', function () {
+    const doc = new PDFDocument();
+    const data = logData(doc);
+    doc.addSpotColor('PANTONE 295 C', 100, 53, 0, 67);
+    doc.fillColor('PANTONE 295 C').text('This text uses spaced spot color!');
+    doc.end();
+
+    expect(data).toContainChunk([
+      `8 0 obj`,
+      '[/Separation /PANTONE#20295#20C /DeviceCMYK <<\n' +
+        '/Range [0 1 0 1 0 1 0 1]\n' +
+        '/C0 [0 0 0 0]\n' +
+        '/C1 [1 0.53 0 0.67]\n' +
+        '/FunctionType 2\n' +
+        '/Domain [0 1]\n' +
+        '/N 1\n' +
+        '>>]',
+    ]);
+  });
 });

--- a/tests/unit/object.spec.js
+++ b/tests/unit/object.spec.js
@@ -19,8 +19,10 @@ describe('PDFObject', () => {
     });
 
     test('String object with spaces should not escape', () => {
-      // Objects are not used to represent PDF object names, so they should not be escaped
-      expect(PDFObject.convert(new String('test with spaces'))).toEqual('(test with spaces)');
+      // Objects are not used to represent PDF object names directly, so they should not be escaped
+      expect(PDFObject.convert(new String('test with spaces'))).toEqual(
+        '(test with spaces)',
+      );
     });
 
     test('String object with unicode', () => {

--- a/tests/unit/object.spec.js
+++ b/tests/unit/object.spec.js
@@ -10,8 +10,17 @@ describe('PDFObject', () => {
       expect(PDFObject.convert('αβγδ')).toEqual('/αβγδ');
     });
 
+    test('string literal with spaces should escape', () => {
+      expect(PDFObject.convert('PANTONE 295 C')).toEqual('/PANTONE#20295#20C');
+    });
+
     test('String object', () => {
       expect(PDFObject.convert(new String('test'))).toEqual('(test)');
+    });
+
+    test('String object with spaces should not escape', () => {
+      // Objects are not used to represent PDF object names, so they should not be escaped
+      expect(PDFObject.convert(new String('test with spaces'))).toEqual('(test with spaces)');
     });
 
     test('String object with unicode', () => {

--- a/tests/unit/object.spec.js
+++ b/tests/unit/object.spec.js
@@ -1,4 +1,4 @@
-import PDFObject from '../../lib/object';
+import PDFObject, { escapeName } from '../../lib/object';
 
 describe('PDFObject', () => {
   describe('convert', () => {
@@ -10,25 +10,24 @@ describe('PDFObject', () => {
       expect(PDFObject.convert('αβγδ')).toEqual('/αβγδ');
     });
 
-    test('string literal with spaces should escape', () => {
-      expect(PDFObject.convert('PANTONE 295 C')).toEqual('/PANTONE#20295#20C');
-    });
-
     test('String object', () => {
       expect(PDFObject.convert(new String('test'))).toEqual('(test)');
-    });
-
-    test('String object with spaces should not escape', () => {
-      // Objects are not used to represent PDF object names directly, so they should not be escaped
-      expect(PDFObject.convert(new String('test with spaces'))).toEqual(
-        '(test with spaces)',
-      );
     });
 
     test('String object with unicode', () => {
       const result = PDFObject.convert(new String('αβγδ'));
       expect(result.length).toEqual(12);
       expect(result).toMatchInlineSnapshot(`"(þÿ±²³´)"`);
+    });
+  });
+
+  describe('escapeName', () => {
+    test('should escape unsafe characters', () => {
+      expect(escapeName('PANTONE 295 C')).toEqual('PANTONE#20295#20C');
+    });
+
+    test('should not escape safe characters', () => {
+      expect(escapeName('PANTONE-295_C')).toEqual('PANTONE-295_C');
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix, making sure we're not sending un-escaped chars to the PDF object name.
Fixes: #1644 

**Checklist**:
- [X] Unit Tests
- [ ] Documentation N/A
- [X] Update CHANGELOG.md
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Having traced where the `.convert(` method is being used, this is the easiest way to get the fix in, happy to look at alternatives if we feel it's too broad. 