### PR TITLE
refactor: use byte-level PNG magic check in image.js

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -28,7 +28,12 @@ class PDFImage {
 
     if (data[0] === 0xff && data[1] === 0xd8) {
       return new JPEG(data, label);
-    } else if (data[0] === 0x89 && data.toString('ascii', 1, 4) === 'PNG') {
+    } else if (
+      data[0] === 0x89 &&
+      data[1] === 0x50 &&
+      data[2] === 0x4e &&
+      data[3] === 0x47
+    ) {
       return new PNG(data, label);
     } else {
       throw new Error('Unknown image format.');


### PR DESCRIPTION
## Summary

Related to https://github.com/foliojs/pdfkit/pull/1717

Make PDFKit not to depend on node dependencies
