### PR TITLE
Omit AcroForm field options with an undefined value

### DIFF
--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -199,6 +199,14 @@ export default {
       opts.Parent = opts.parent;
       delete opts.parent;
     }
+    // Drop entries with an `undefined` value so they are not serialized as the
+    // literal token `undefined` (e.g. `/SomeKey undefined`), which produces an
+    // invalid PDF object that strict parsers reject.
+    Object.keys(opts).forEach((key) => {
+      if (opts[key] === undefined) {
+        delete opts[key];
+      }
+    });
     return opts;
   },
 

--- a/tests/unit/acroform.spec.js
+++ b/tests/unit/acroform.spec.js
@@ -204,6 +204,26 @@ describe('acroform', () => {
 
       expect(docData).toContainChunk(expectedDocData);
     });
+
+    test('options with an undefined value are omitted', () => {
+      // A field created with an extra option set to `undefined` must serialize
+      // identically to one created without that option at all - the key must
+      // not leak into the dictionary as the literal token `undefined`, which is
+      // an invalid PDF object that strict parsers reject (issue #1735).
+      const expectedDoc = new PDFDocument({
+        info: { CreationDate: new Date(Date.UTC(2018, 1, 1)) },
+      });
+      expectedDoc.initForm();
+      const expectedDocData = logData(expectedDoc);
+      expectedDoc.formText('demofield', 20, 20, 50, 20, {});
+
+      doc.initForm();
+      const docData = logData(doc);
+      doc.formText('demofield', 20, 20, 50, 20, { CustomKey: undefined });
+
+      expect(docData.join('')).not.toMatch(/undefined/);
+      expect(docData).toContainChunk(expectedDocData);
+    });
   });
 
   test('flags', () => {


### PR DESCRIPTION
Fixes #1735.

### Problem

Passing a field option whose value is `undefined` to `doc.form*()` causes that key to be serialized as the literal token `undefined`:

```js
doc.formText("demofield", 10, 692, 200, 40, { someOption: undefined });
```

```
10 0 obj
<<
/someOption undefined   <-- invalid: a name key with no value object
/FT /Tx
/T (demofield)
...
>>
endobj
```

A name key followed by the bare token `undefined` is not a valid PDF object. Lenient viewers tolerate it, but strict parsers reject it — the issue reports iText RUPS throwing `NullPointerException` ("object is null") on such a field.

#1738 ("Normalize nullish AcroForm text values to empty strings") addressed only the mapped `value`/`defaultValue` keys via `VALUE_MAP`. Any *other* option passed as `undefined` still leaks into the dictionary, so the broader issue #1735 remains.

### Fix

Drop entries whose value is `undefined` in `_fieldDict`, right before the dictionary is returned. A field created with an extra `undefined` option then serializes byte-for-byte identically to one created without that option at all. Defined options (including those legitimately set to falsy values like `0`, `false`, or `""`) are untouched.

### Tests

Added a unit test (`tests/unit/acroform.spec.js`) asserting that a field built with `{ CustomKey: undefined }` contains no `undefined` token and matches the output of the same field built with `{}`.

- Fails without the fix (the dictionary contains `/CustomKey undefined`).
- Passes with the fix.
- Full unit suite: 318 passing. ESLint and Prettier clean.