### PR TITLE
Bugfix: Handle TypedArrays and Buffers in deep-merge/clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Fix Table style merging crashes when passing fonts as buffer (#1743)
+
 ### [v0.19.1] - 2026-06-10
 
 - Fix RGB JPEG embedded as DeviceGray (0.19.0 regression) (#1734)

--- a/lib/table/normalize.js
+++ b/lib/table/normalize.js
@@ -94,7 +94,9 @@ export function normalizeCell(cell, rowIndex, colIndex) {
   let rowStyle = this._rowStyle(rowIndex);
 
   const font = {
-    ...(cell.font || rowStyle.font || colStyle.font),
+    ...((cell.font?.src && cell.font) ||
+      (rowStyle.font?.src && rowStyle.font) ||
+      (colStyle.font?.src && colStyle.font)),
     size: cell.font?.size || rowStyle.font?.size || colStyle.font?.size,
   };
   const customFont = Object.values(font).filter((v) => v != null).length > 0;

--- a/lib/table/normalize.js
+++ b/lib/table/normalize.js
@@ -94,9 +94,8 @@ export function normalizeCell(cell, rowIndex, colIndex) {
   let rowStyle = this._rowStyle(rowIndex);
 
   const font = {
-    ...colStyle.font,
-    ...rowStyle.font,
-    ...cell.font,
+    ...(cell.font || rowStyle.font || colStyle.font),
+    size: cell.font?.size || rowStyle.font?.size || colStyle.font?.size,
   };
   const customFont = Object.values(font).filter((v) => v != null).length > 0;
   const doc = this.document;

--- a/lib/table/normalize.js
+++ b/lib/table/normalize.js
@@ -93,7 +93,11 @@ export function normalizeCell(cell, rowIndex, colIndex) {
   const colStyle = this._colStyle(colIndex);
   let rowStyle = this._rowStyle(rowIndex);
 
-  const font = deepMerge({}, colStyle.font, rowStyle.font, cell.font);
+  const font = {
+    ...colStyle.font,
+    ...rowStyle.font,
+    ...cell.font,
+  };
   const customFont = Object.values(font).filter((v) => v != null).length > 0;
   const doc = this.document;
 

--- a/lib/table/style.js
+++ b/lib/table/style.js
@@ -62,8 +62,8 @@ export function normalizedRowStyle(defaultRowStyle, rowStyleInternal, i) {
   const { font: defaultFont, ...restDefaultStyle } = defaultRowStyle || {};
   const { font: font, ...restStyle } = rowStyle || {};
   const mergedFont = {
-    ...defaultFont,
-    ...font,
+    ...(font || defaultFont),
+    size: font?.size || defaultFont?.size,
   };
 
   // Merge defaults
@@ -127,8 +127,8 @@ export function normalizedColumnStyle(defaultColStyle, colStyleInternal, i) {
   const { font: defaultFont, ...restDefaultStyle } = defaultColStyle || {};
   const { font: font, ...restStyle } = colStyle || {};
   const mergedFont = {
-    ...defaultFont,
-    ...font,
+    ...(font || defaultFont),
+    size: font?.size || defaultFont?.size,
   };
 
   // Merge defaults

--- a/lib/table/style.js
+++ b/lib/table/style.js
@@ -58,8 +58,17 @@ export function normalizedRowStyle(defaultRowStyle, rowStyleInternal, i) {
   rowStyle.borderColor = normalizeSides(rowStyle.borderColor);
   rowStyle.align = normalizeAlignment(rowStyle.align);
 
+  // extract fonts
+  const { font: defaultFont, ...restDefaultStyle } = defaultRowStyle || {};
+  const { font: font, ...restStyle } = rowStyle || {};
+  const mergedFont = {
+    ...defaultFont,
+    ...font,
+  };
+
   // Merge defaults
-  rowStyle = deepMerge(defaultRowStyle, rowStyle);
+  rowStyle = deepMerge(restDefaultStyle, restStyle);
+  rowStyle.font = mergedFont;
 
   const document = this.document;
   const page = document.page;
@@ -114,8 +123,17 @@ export function normalizedColumnStyle(defaultColStyle, colStyleInternal, i) {
   colStyle.borderColor = normalizeSides(colStyle.borderColor);
   colStyle.align = normalizeAlignment(colStyle.align);
 
+  // extract fonts
+  const { font: defaultFont, ...restDefaultStyle } = defaultColStyle || {};
+  const { font: font, ...restStyle } = colStyle || {};
+  const mergedFont = {
+    ...defaultFont,
+    ...font,
+  };
+
   // Merge defaults
-  colStyle = deepMerge(defaultColStyle, colStyle);
+  colStyle = deepMerge(restDefaultStyle, restStyle);
+  colStyle.font = mergedFont;
 
   if (colStyle.width == null || colStyle.width === '*') {
     colStyle.width = '*';

--- a/lib/table/style.js
+++ b/lib/table/style.js
@@ -62,7 +62,7 @@ export function normalizedRowStyle(defaultRowStyle, rowStyleInternal, i) {
   const { font: defaultFont, ...restDefaultStyle } = defaultRowStyle || {};
   const { font: font, ...restStyle } = rowStyle || {};
   const mergedFont = {
-    ...(font || defaultFont),
+    ...((font?.src && font) || (defaultFont?.src && defaultFont)),
     size: font?.size || defaultFont?.size,
   };
 
@@ -127,7 +127,7 @@ export function normalizedColumnStyle(defaultColStyle, colStyleInternal, i) {
   const { font: defaultFont, ...restDefaultStyle } = defaultColStyle || {};
   const { font: font, ...restStyle } = colStyle || {};
   const mergedFont = {
-    ...(font || defaultFont),
+    ...((font?.src && font) || (defaultFont?.src && defaultFont)),
     size: font?.size || defaultFont?.size,
   };
 

--- a/lib/table/utils.js
+++ b/lib/table/utils.js
@@ -335,9 +335,8 @@ function isObject(item) {
  * @param item
  * @returns {boolean}
  */
-function isBuffer(item) {
+function isBinaryData(item) {
   return (
-    isObject(item) &&
     (item instanceof Uint8Array || item instanceof ArrayBuffer)
   );
 }

--- a/lib/table/utils.js
+++ b/lib/table/utils.js
@@ -331,6 +331,25 @@ function isObject(item) {
 }
 
 /**
+ * TypedArray check.
+ * @param item
+ * @returns {boolean}
+ */
+function isTypedArray(item) {
+  return (
+    isObject(item) &&
+    item.length !== undefined &&
+    (item instanceof Uint8Array ||
+      item instanceof Uint8ClampedArray ||
+      item instanceof Uint16Array ||
+      item instanceof Uint32Array ||
+      item instanceof Int8Array ||
+      item instanceof Int16Array ||
+      item instanceof Int32Array)
+  );
+}
+
+/**
  * Deep merge two objects.
  *
  * @template T
@@ -345,7 +364,7 @@ export function deepMerge(target, ...sources) {
   for (const source of sources) {
     if (isObject(source)) {
       for (const key in source) {
-        if (isObject(source[key])) {
+        if (isObject(source[key]) && !isTypedArray(source[key])) {
           if (!(key in target)) target[key] = {};
           target[key] = deepMerge(target[key], source[key]);
         } else if (source[key] !== undefined) {
@@ -360,7 +379,13 @@ export function deepMerge(target, ...sources) {
 
 function deepClone(obj) {
   let result = obj;
-  if (obj && typeof obj == 'object') {
+  if (isTypedArray(obj)) {
+    if (Buffer.isBuffer(obj)) {
+      result = Buffer.from(obj);
+    } else {
+      result = obj.slice();
+    }
+  } else if (obj && typeof obj == 'object') {
     result = Array.isArray(obj) ? [] : {};
     for (const key in obj) result[key] = deepClone(obj[key]);
   }

--- a/lib/table/utils.js
+++ b/lib/table/utils.js
@@ -336,9 +336,7 @@ function isObject(item) {
  * @returns {boolean}
  */
 function isBinaryData(item) {
-  return (
-    (item instanceof Uint8Array || item instanceof ArrayBuffer)
-  );
+  return item instanceof Uint8Array || item instanceof ArrayBuffer;
 }
 
 /**
@@ -356,7 +354,7 @@ export function deepMerge(target, ...sources) {
   for (const source of sources) {
     if (isObject(source)) {
       for (const key in source) {
-        if (isObject(source[key]) && !isBuffer(source[key])) {
+        if (isObject(source[key]) && !isBinaryData(source[key])) {
           if (!(key in target)) target[key] = {};
           target[key] = deepMerge(target[key], source[key]);
         } else if (source[key] !== undefined) {
@@ -371,7 +369,7 @@ export function deepMerge(target, ...sources) {
 
 function deepClone(obj) {
   let result = obj;
-  if (isBuffer(obj)) {
+  if (isBinaryData(obj)) {
     result = obj;
   } else if (obj && typeof obj == 'object') {
     result = Array.isArray(obj) ? [] : {};

--- a/lib/table/utils.js
+++ b/lib/table/utils.js
@@ -331,21 +331,14 @@ function isObject(item) {
 }
 
 /**
- * TypedArray check.
+ * buffer check.
  * @param item
  * @returns {boolean}
  */
-function isTypedArray(item) {
+function isBuffer(item) {
   return (
     isObject(item) &&
-    item.length !== undefined &&
-    (item instanceof Uint8Array ||
-      item instanceof Uint8ClampedArray ||
-      item instanceof Uint16Array ||
-      item instanceof Uint32Array ||
-      item instanceof Int8Array ||
-      item instanceof Int16Array ||
-      item instanceof Int32Array)
+    (item instanceof Uint8Array || item instanceof ArrayBuffer)
   );
 }
 
@@ -364,7 +357,7 @@ export function deepMerge(target, ...sources) {
   for (const source of sources) {
     if (isObject(source)) {
       for (const key in source) {
-        if (isObject(source[key]) && !isTypedArray(source[key])) {
+        if (isObject(source[key]) && !isBuffer(source[key])) {
           if (!(key in target)) target[key] = {};
           target[key] = deepMerge(target[key], source[key]);
         } else if (source[key] !== undefined) {
@@ -379,12 +372,8 @@ export function deepMerge(target, ...sources) {
 
 function deepClone(obj) {
   let result = obj;
-  if (isTypedArray(obj)) {
-    if (Buffer.isBuffer(obj)) {
-      result = Buffer.from(obj);
-    } else {
-      result = obj.slice();
-    }
+  if (isBuffer(obj)) {
+    result = obj;
   } else if (obj && typeof obj == 'object') {
     result = Array.isArray(obj) ? [] : {};
     for (const key in obj) result[key] = deepClone(obj[key]);

--- a/tests/unit/table.spec.js
+++ b/tests/unit/table.spec.js
@@ -106,9 +106,6 @@ describe('table', () => {
     });
 
     test('merge table font', () => {
-      const colFamily = 'family1';
-      const rowFamily = 'family2';
-      const cellFamily = 'family3';
       const fontSrcs = {
         colStandardFont: 'Courier',
         colFontPath: 'tests/fonts/Roboto-Regular.ttf',
@@ -151,59 +148,55 @@ describe('table', () => {
 
       const table = document.table({
         columnStyles: [
-          { font: { src: fontSrcs.colStandardFont, family: colFamily } },
-          { font: { src: fontSrcs.colFontPath, family: colFamily } },
-          { font: { src: fontSrcs.colFontBuffer, family: colFamily } },
+          { font: { src: fontSrcs.colStandardFont } },
+          { font: { src: fontSrcs.colFontPath } },
+          { font: { src: fontSrcs.colFontBuffer } },
         ],
         rowStyles: [
           {},
-          { font: { src: fontSrcs.rowStandardFont, family: rowFamily } },
-          { font: { src: fontSrcs.rowFontPath, family: rowFamily } },
-          { font: { src: fontSrcs.rowFontBuffer, family: rowFamily } },
-          { font: { src: fontSrcs.rowFontBuffer, family: rowFamily } },
+          { font: { src: fontSrcs.rowStandardFont } },
+          { font: { src: fontSrcs.rowFontPath } },
+          { font: { src: fontSrcs.rowFontBuffer } },
+          { font: { src: fontSrcs.rowFontBuffer } },
         ],
       });
       // fonts in column styles
       fontSpy.mockClear();
       table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
       expectFonts(fontSpy, [
-        { src: fontSrcs.colStandardFont, family: colFamily },
-        { src: fontSrcs.colFontPath, family: colFamily },
-        { src: fontSrcs.colFontBuffer, family: colFamily },
+        { src: fontSrcs.colStandardFont },
+        { src: fontSrcs.colFontPath },
+        { src: fontSrcs.colFontBuffer },
       ]);
 
       // fonts in column + row styles
       fontSpy.mockClear();
       table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
-      expectFonts(fontSpy, [
-        { src: fontSrcs.rowStandardFont, family: rowFamily },
-      ]);
+      expectFonts(fontSpy, [{ src: fontSrcs.rowStandardFont }]);
       fontSpy.mockClear();
       table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
-      expectFonts(fontSpy, [{ src: fontSrcs.rowFontPath, family: rowFamily }]);
+      expectFonts(fontSpy, [{ src: fontSrcs.rowFontPath }]);
       fontSpy.mockClear();
       table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
-      expectFonts(fontSpy, [
-        { src: fontSrcs.rowFontBuffer, family: rowFamily },
-      ]);
+      expectFonts(fontSpy, [{ src: fontSrcs.rowFontBuffer }]);
 
       // fonts in column + row + cell style
       fontSpy.mockClear();
       table.row([
         {
           text: 'A',
-          font: { src: fontSrcs.cellStandardFont, family: cellFamily },
+          font: { src: fontSrcs.cellStandardFont },
         },
-        { text: 'B', font: { src: fontSrcs.cellFontPath, family: cellFamily } },
+        { text: 'B', font: { src: fontSrcs.cellFontPath } },
         {
           text: 'C',
-          font: { src: fontSrcs.cellFontBuffer, family: cellFamily },
+          font: { src: fontSrcs.cellFontBuffer },
         },
       ]);
       expectFonts(fontSpy, [
-        { src: fontSrcs.cellStandardFont, family: cellFamily },
-        { src: fontSrcs.cellFontPath, family: cellFamily },
-        { src: fontSrcs.cellFontBuffer, family: cellFamily },
+        { src: fontSrcs.cellStandardFont },
+        { src: fontSrcs.cellFontPath },
+        { src: fontSrcs.cellFontBuffer },
       ]);
     });
   });

--- a/tests/unit/table.spec.js
+++ b/tests/unit/table.spec.js
@@ -17,7 +17,7 @@ describe('table', () => {
   });
 
   describe('font', () => {
-    test('colum standard font', () => {
+    test('column standard font', () => {
       const document = new PDFDocument();
       const table = document.table({
         columnStyles: {
@@ -28,7 +28,7 @@ describe('table', () => {
       expect(table._columnWidths.length).toBe(1);
     });
 
-    test('colum embeded font with path', () => {
+    test('column embeded font with path', () => {
       const document = new PDFDocument();
       const table = document.table({
         columnStyles: {
@@ -39,7 +39,7 @@ describe('table', () => {
       expect(table._columnWidths.length).toBe(1);
     });
 
-    test('colum embeded font with Buffer', () => {
+    test('column embeded font with Buffer', () => {
       const document = new PDFDocument();
       const buffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
       console.log('buffer instanceof Buffer:', buffer instanceof Buffer);

--- a/tests/unit/table.spec.js
+++ b/tests/unit/table.spec.js
@@ -1,6 +1,7 @@
 import PDFDocument from '../../lib/document';
 import PDFTable from '../../lib/table';
 import { deepMerge } from '../../lib/table/utils';
+import fs from 'fs';
 
 describe('table', () => {
   test('created', () => {
@@ -13,6 +14,124 @@ describe('table', () => {
     const table = document.table();
     table.row(['A', 'B', 'C']);
     expect(table._columnWidths.length).toBe(3);
+  });
+
+  describe('font', () => {
+    test('colum standard font', () => {
+      const document = new PDFDocument();
+      const table = document.table({
+        columnStyles: {
+          font: { src: 'Courier' },
+        },
+      });
+      table.row(['A']);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('colum embeded font with path', () => {
+      const document = new PDFDocument();
+      const table = document.table({
+        columnStyles: {
+          font: { src: 'tests/fonts/Roboto-Regular.ttf' },
+        },
+      });
+      table.row(['A']);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('colum embeded font with Buffer', () => {
+      const document = new PDFDocument();
+      const buffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
+      console.log('buffer instanceof Buffer:', buffer instanceof Buffer);
+      const table = document.table({
+        columnStyles: {
+          font: {
+            src: buffer,
+          },
+        },
+      });
+      table.row(['A']);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('row standard font', () => {
+      const document = new PDFDocument();
+      const table = document.table({
+        rowStyles: {
+          font: { src: 'Courier' },
+        },
+      });
+      table.row(['A']);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('row embeded font with path', () => {
+      const document = new PDFDocument();
+      const table = document.table({
+        rowStyles: {
+          font: { src: 'tests/fonts/Roboto-Regular.ttf' },
+        },
+      });
+      table.row(['A']);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('row embeded font with Buffer', () => {
+      const document = new PDFDocument();
+      const buffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
+      console.log('buffer instanceof Buffer:', buffer instanceof Buffer);
+      const table = document.table({
+        rowStyles: {
+          font: {
+            src: buffer,
+          },
+        },
+      });
+      table.row(['A']);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('cell standard font', () => {
+      const document = new PDFDocument();
+      const table = document.table();
+      table.row([
+        {
+          text: 'A',
+          font: {
+            src: 'Courier',
+          },
+        },
+      ]);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('cell embeded font with path', () => {
+      const document = new PDFDocument();
+      const table = document.table();
+      table.row([
+        {
+          text: 'A',
+          font: {
+            src: 'tests/fonts/Roboto-Regular.ttf',
+          },
+        },
+      ]);
+      expect(table._columnWidths.length).toBe(1);
+    });
+
+    test('cell embeded font with Buffer', () => {
+      const document = new PDFDocument();
+      const table = document.table();
+      table.row([
+        {
+          text: 'A',
+          font: {
+            src: fs.readFileSync('tests/fonts/Roboto-Regular.ttf'),
+          },
+        },
+      ]);
+      expect(table._columnWidths.length).toBe(1);
+    });
   });
 });
 
@@ -28,6 +147,16 @@ describe('utils', () => {
       [1, {}, 1],
       [{ a: 'hello' }, { a: {} }, { a: 'hello' }],
       [{ a: { b: 'hello' } }, { a: { b: 'world' } }, { a: { b: 'world' } }],
+      [
+        { a: Buffer.from([1, 2, 3]) },
+        { b: Buffer.from([4, 5, 6]) },
+        { a: Buffer.from([1, 2, 3]), b: Buffer.from([4, 5, 6]) },
+      ],
+      [
+        { a: new Uint8Array([1, 2, 3]) },
+        { b: new Uint8Array([4, 5, 6]) },
+        { a: new Uint8Array([1, 2, 3]), b: new Uint8Array([4, 5, 6]) },
+      ],
     ])('%o -> %o', function () {
       const opts = Array.from(arguments);
       const expected = opts.splice(-1, 1)[0];

--- a/tests/unit/table.spec.js
+++ b/tests/unit/table.spec.js
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import PDFDocument from '../../lib/document';
 import PDFTable from '../../lib/table';
 import { deepMerge } from '../../lib/table/utils';
@@ -17,120 +18,193 @@ describe('table', () => {
   });
 
   describe('font', () => {
-    test('column standard font', () => {
+    test('column font', () => {
+      const standardFont = 'Courier';
+      const fontPath = 'tests/fonts/Roboto-Regular.ttf';
+      const fontBuffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
       const document = new PDFDocument();
+      const fontSpy = vi.spyOn(document, 'font');
+
       const table = document.table({
-        columnStyles: {
-          font: { src: 'Courier' },
-        },
+        columnStyles: [
+          { font: { src: standardFont } },
+          { font: { src: fontPath } },
+          { font: { src: fontBuffer } },
+        ],
       });
-      table.row(['A']);
-      expect(table._columnWidths.length).toBe(1);
+      table.row(['A', 'B', 'C']);
+      expect(fontSpy).toHaveBeenCalledWith(
+        standardFont,
+        expect.toSatisfy(() => true),
+      );
+      expect(fontSpy).toHaveBeenCalledWith(
+        fontPath,
+        expect.toSatisfy(() => true),
+      );
+      expect(fontSpy).toHaveBeenCalledWith(
+        fontBuffer,
+        expect.toSatisfy(() => true),
+      );
     });
 
-    test('column embeded font with path', () => {
+    test('row font', () => {
+      const standardFont = 'Courier';
+      const fontPath = 'tests/fonts/Roboto-Regular.ttf';
+      const fontBuffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
       const document = new PDFDocument();
+      const fontSpy = vi.spyOn(document, 'font');
+
       const table = document.table({
-        columnStyles: {
-          font: { src: 'tests/fonts/Roboto-Regular.ttf' },
-        },
+        rowStyles: [
+          { font: { src: standardFont } },
+          { font: { src: fontPath } },
+          { font: { src: fontBuffer } },
+        ],
       });
       table.row(['A']);
-      expect(table._columnWidths.length).toBe(1);
+      table.row(['B']);
+      table.row(['C']);
+      expect(fontSpy).toHaveBeenCalledWith(
+        standardFont,
+        expect.toSatisfy(() => true),
+      );
+      expect(fontSpy).toHaveBeenCalledWith(
+        fontPath,
+        expect.toSatisfy(() => true),
+      );
+      expect(fontSpy).toHaveBeenCalledWith(
+        fontBuffer,
+        expect.toSatisfy(() => true),
+      );
     });
 
-    test('column embeded font with Buffer', () => {
+    test('cell font', () => {
+      const standardFont = 'Courier';
+      const fontPath = 'tests/fonts/Roboto-Regular.ttf';
+      const fontBuffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
       const document = new PDFDocument();
-      const buffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
-      console.log('buffer instanceof Buffer:', buffer instanceof Buffer);
-      const table = document.table({
-        columnStyles: {
-          font: {
-            src: buffer,
-          },
-        },
-      });
-      table.row(['A']);
-      expect(table._columnWidths.length).toBe(1);
-    });
+      const fontSpy = vi.spyOn(document, 'font');
 
-    test('row standard font', () => {
-      const document = new PDFDocument();
-      const table = document.table({
-        rowStyles: {
-          font: { src: 'Courier' },
-        },
-      });
-      table.row(['A']);
-      expect(table._columnWidths.length).toBe(1);
-    });
-
-    test('row embeded font with path', () => {
-      const document = new PDFDocument();
-      const table = document.table({
-        rowStyles: {
-          font: { src: 'tests/fonts/Roboto-Regular.ttf' },
-        },
-      });
-      table.row(['A']);
-      expect(table._columnWidths.length).toBe(1);
-    });
-
-    test('row embeded font with Buffer', () => {
-      const document = new PDFDocument();
-      const buffer = fs.readFileSync('tests/fonts/Roboto-Regular.ttf');
-      console.log('buffer instanceof Buffer:', buffer instanceof Buffer);
-      const table = document.table({
-        rowStyles: {
-          font: {
-            src: buffer,
-          },
-        },
-      });
-      table.row(['A']);
-      expect(table._columnWidths.length).toBe(1);
-    });
-
-    test('cell standard font', () => {
-      const document = new PDFDocument();
       const table = document.table();
+      table.row([
+        { text: 'A', font: { src: standardFont } },
+        { text: 'B', font: { src: fontPath } },
+        { text: 'C', font: { src: fontBuffer } },
+      ]);
+      expect(fontSpy).toHaveBeenCalledWith(
+        standardFont,
+        expect.toSatisfy(() => true),
+      );
+      expect(fontSpy).toHaveBeenCalledWith(
+        fontPath,
+        expect.toSatisfy(() => true),
+      );
+      expect(fontSpy).toHaveBeenCalledWith(
+        fontBuffer,
+        expect.toSatisfy(() => true),
+      );
+    });
+
+    test('merge table font', () => {
+      const colFamily = 'family1';
+      const rowFamily = 'family2';
+      const cellFamily = 'family3';
+      const fontSrcs = {
+        colStandardFont: 'Courier',
+        colFontPath: 'tests/fonts/Roboto-Regular.ttf',
+        colFontBuffer: fs.readFileSync('tests/fonts/Roboto-Regular.ttf'),
+        rowStandardFont: 'Courier-Bold',
+        rowFontPath: 'tests/fonts/Roboto-Medium.ttf',
+        rowFontBuffer: fs.readFileSync('tests/fonts/Roboto-Medium.ttf'),
+        cellStandardFont: 'Courier-Oblique',
+        cellFontPath: 'tests/fonts/Roboto-MediumItalic.ttf',
+        cellFontBuffer: fs.readFileSync('tests/fonts/Roboto-MediumItalic.ttf'),
+      };
+      const fontSrcSet = Object.values(fontSrcs);
+
+      /**
+       * Check whether given spy has been called with specified allowed fonts
+       * and not other fonts within concerned font set
+       * @param {*} fontSpy
+       * @param {import('../../lib/table/utils').Font[]} allowedFonts
+       */
+      function expectFonts(
+        fontSpy,
+        allowedFonts = [],
+        testedFonts = fontSrcSet,
+      ) {
+        const allowedFontSrc = allowedFonts.map((font) => {
+          expect(fontSpy).toHaveBeenCalledWith(font.src, font.family);
+          return font.src;
+        });
+        testedFonts.forEach((fontSrc) => {
+          if (!allowedFontSrc.includes(fontSrc)) {
+            expect(fontSpy).not.toHaveBeenCalledWith(
+              fontSrc,
+              expect.toSatisfy(() => true),
+            );
+          }
+        });
+      }
+      const document = new PDFDocument();
+      const fontSpy = vi.spyOn(document, 'font');
+
+      const table = document.table({
+        columnStyles: [
+          { font: { src: fontSrcs.colStandardFont, family: colFamily } },
+          { font: { src: fontSrcs.colFontPath, family: colFamily } },
+          { font: { src: fontSrcs.colFontBuffer, family: colFamily } },
+        ],
+        rowStyles: [
+          {},
+          { font: { src: fontSrcs.rowStandardFont, family: rowFamily } },
+          { font: { src: fontSrcs.rowFontPath, family: rowFamily } },
+          { font: { src: fontSrcs.rowFontBuffer, family: rowFamily } },
+          { font: { src: fontSrcs.rowFontBuffer, family: rowFamily } },
+        ],
+      });
+      // fonts in column styles
+      fontSpy.mockClear();
+      table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
+      expectFonts(fontSpy, [
+        { src: fontSrcs.colStandardFont, family: colFamily },
+        { src: fontSrcs.colFontPath, family: colFamily },
+        { src: fontSrcs.colFontBuffer, family: colFamily },
+      ]);
+
+      // fonts in column + row styles
+      fontSpy.mockClear();
+      table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
+      expectFonts(fontSpy, [
+        { src: fontSrcs.rowStandardFont, family: rowFamily },
+      ]);
+      fontSpy.mockClear();
+      table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
+      expectFonts(fontSpy, [{ src: fontSrcs.rowFontPath, family: rowFamily }]);
+      fontSpy.mockClear();
+      table.row([{ text: 'A' }, { text: 'B' }, { text: 'C' }]);
+      expectFonts(fontSpy, [
+        { src: fontSrcs.rowFontBuffer, family: rowFamily },
+      ]);
+
+      // fonts in column + row + cell style
+      fontSpy.mockClear();
       table.row([
         {
           text: 'A',
-          font: {
-            src: 'Courier',
-          },
+          font: { src: fontSrcs.cellStandardFont, family: cellFamily },
         },
-      ]);
-      expect(table._columnWidths.length).toBe(1);
-    });
-
-    test('cell embeded font with path', () => {
-      const document = new PDFDocument();
-      const table = document.table();
-      table.row([
+        { text: 'B', font: { src: fontSrcs.cellFontPath, family: cellFamily } },
         {
-          text: 'A',
-          font: {
-            src: 'tests/fonts/Roboto-Regular.ttf',
-          },
+          text: 'C',
+          font: { src: fontSrcs.cellFontBuffer, family: cellFamily },
         },
       ]);
-      expect(table._columnWidths.length).toBe(1);
-    });
-
-    test('cell embeded font with Buffer', () => {
-      const document = new PDFDocument();
-      const table = document.table();
-      table.row([
-        {
-          text: 'A',
-          font: {
-            src: fs.readFileSync('tests/fonts/Roboto-Regular.ttf'),
-          },
-        },
+      expectFonts(fontSpy, [
+        { src: fontSrcs.cellStandardFont, family: cellFamily },
+        { src: fontSrcs.cellFontPath, family: cellFamily },
+        { src: fontSrcs.cellFontBuffer, family: cellFamily },
       ]);
-      expect(table._columnWidths.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
## What kind of change does this PR introduce?
This fixes #1743 where providing font buffers crashes table generation.

In `lib\table\utils.js`, `deepMerge` and `deepClone()` copy properties key by key including `Buffer` and `Uint8Array` without inheriting the class. This causes the merged font buffer failing to be recognised by `PDFFontFactory` which relies on `instanceof` to determine the type of font sources.

Also fixes #1746 where table style merging falsely assign font families.

### This PR changes:

- `deepMerge()` and `deepClone()` now clone TypedArrays and Buffers using `.slice()` and `Buffer.from(buffer)` respectively.

- Table style merging is modified to copy fonts by reference.

Additional unit tests (fonts in tables, deep-merging buffers) are added for the changes.

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Documentation
- [x] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

## TODO: 
