### PR TITLE
fix: render README example as code block instead of plain text

### DIFF
--- a/docs/generate_website.js
+++ b/docs/generate_website.js
@@ -134,8 +134,8 @@ for (let file of Array.from(files)) {
 
   // turn github highlighted code blocks into normal markdown code blocks
   content = content.replace(
-    /^```javascript\n((:?.|\n)*?)\n```/gm,
-    (m, $1) => `    ${$1.split('\n').join('\n    ')}`,
+    /^```(?:javascript|js|bash)\r?\n([\s\S]*?)\r?\n```/gm,
+    (m, $1) => `    ${$1.split(/\r?\n/).join('\n    ')}`,
   );
 
   const tree = markdown.parse(content);


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**
Bug fix, this PR fixes the issue of rendering the code examples as plain text on the main website. This was due to generation of empty code elements `<p><code></code> "code here" <code></code></p>` . All this was happening due to the regex in thie generate_website.js. 

Fixes: #1592 

Before fixes
<img width="1507" height="597" alt="image" src="https://github.com/user-attachments/assets/7670181e-1758-477a-b4c7-d0ed50d8b9ef" />

After fixes
<img width="485" height="617" alt="image" src="https://github.com/user-attachments/assets/1b08132d-f2d7-473c-9292-2c33b1f7c28d" />

<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [x] Documentation
- [ ] Update CHANGELOG.md
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Feel free to correct me! 
I was using pdfkit first time and noticed the code as plain text.