### PR TITLE
fix: handle postscriptName as Uint8Array in EmbeddedFont

### DIFF
--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -4,6 +4,23 @@ const toHex = function (num) {
   return `0000${num.toString(16)}`.slice(-4);
 };
 
+// fontkit's readString() can return a raw Uint8Array instead of a string when the
+// runtime's TextDecoder doesn't support the font's encoding (e.g. x-mac-roman,
+// utf-16be) - notably on Hermes (React Native), which only supports utf-8/utf-16le.
+const postscriptNameToString = function (postscriptName) {
+  if (typeof postscriptName === 'string') {
+    return postscriptName;
+  }
+  if (postscriptName instanceof Uint8Array) {
+    let str = '';
+    for (let i = 0; i < postscriptName.length; i++) {
+      str += String.fromCharCode(postscriptName[i]);
+    }
+    return str;
+  }
+  return String(postscriptName || '');
+};
+
 class EmbeddedFont extends PDFFont {
   constructor(document, font, id) {
     super();
@@ -14,7 +31,7 @@ class EmbeddedFont extends PDFFont {
     this.unicode = [[0]];
     this.widths = [this.font.getGlyph(0).advanceWidth];
 
-    this.name = this.font.postscriptName;
+    this.name = postscriptNameToString(this.font.postscriptName);
     this.scale = 1000 / this.font.unitsPerEm;
     this.ascender = this.font.ascent * this.scale;
     this.descender = this.font.descent * this.scale;
@@ -153,7 +170,8 @@ class EmbeddedFont extends PDFFont {
     const tag = [1, 2, 3, 4, 5, 6]
       .map((i) => String.fromCharCode((this.id.charCodeAt(i) || 73) + 17))
       .join('');
-    const name = tag + '+' + this.font.postscriptName?.replaceAll(' ', '_');
+    const name =
+      tag + '+' + postscriptNameToString(this.font.postscriptName).replace(/ /g, '_');
 
     const { bbox } = this.font;
     const descriptor = this.document.ref({

--- a/tests/unit/font.spec.js
+++ b/tests/unit/font.spec.js
@@ -54,6 +54,32 @@ describe('EmbeddedFont', () => {
 
       expect(dictionary.data.BaseFont).toBe('BAJJZZ+Roboto-Regular');
     });
+
+    // https://github.com/foliojs/pdfkit/issues/1687
+    // fontkit's readString() returns a raw Uint8Array instead of a string when the
+    // runtime's TextDecoder doesn't support the font's encoding - this happens on
+    // Hermes (React Native), which only supports utf-8/utf-16le.
+    test('does not crash when postscriptName is a Uint8Array', () => {
+      const document = new PDFDocument();
+      const font = PDFFontFactory.open(
+        document,
+        'tests/fonts/Roboto-Regular.ttf',
+        undefined,
+        'F1099',
+      );
+      const original = font.font.postscriptName;
+      Object.defineProperty(font.font, 'postscriptName', {
+        value: new Uint8Array(Array.from(original, (c) => c.charCodeAt(0))),
+      });
+
+      const dictionary = {
+        end: () => {},
+      };
+      font.dictionary = dictionary;
+
+      expect(() => font.embed()).not.toThrow();
+      expect(dictionary.data.BaseFont).toBe('BAJJZZ+Roboto-Regular');
+    });
   });
 
   describe('toUnicodeMap', () => {


### PR DESCRIPTION
## Summary

Fixes #1687. `fontkit`'s `readString()` returns a raw `Uint8Array` instead of a string when the runtime's `TextDecoder` doesn't support the font's encoding (e.g. `x-mac-roman`, `utf-16be`). This happens on Hermes (React Native), which only supports `utf-8`/`utf-16le`. `EmbeddedFont` assumed `postscriptName` is always a string and called `.replaceAll(' ', '_')` directly on it, so `embed()` crashed with `TypeError: replaceAll is not a function` on any font whose postscript name needed that fallback decoding path.

## Fix

Added `postscriptNameToString()` (handles `string`, `Uint8Array`, and nullish input) and used it everywhere `postscriptName` was read: both where it's stored as `this.name` in the constructor, and where it's used to build the embedded font's `BaseFont`/`FontName` tag in `embed()`.

## Test plan
- [x] Added a regression test that simulates the Hermes scenario by overriding a real font's `postscriptName` getter to return a `Uint8Array`, then calls `embed()` and asserts it doesn't throw and produces the same `BaseFont` tag as the string path. Confirmed it fails with the exact reported error on the old code, and passes with the fix.
- [x] Full test suite passes (377/377, unit + visual).
- [x] `eslint` clean.