### PR TITLE
fix: stop bare addPage() from re-forcing the document's default font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [BREAKING CHANGE] Restrict AcroForm options to documented mappings and explicit escape hatches.
 - [BREAKING CHANGE] Stop automatically uppercasing annotation option keys.
 - Do not mutate options passed to `doc.annotate()` and its convenience methods (link, note, strike, lineAnnotation, rectAnnotation, ellipseAnnotation, textAnnotation, fileAnnotation)
+- Persist font options when adding a new page. Fixes #1739
 
 ### [v0.19.1] - 2026-06-10
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -142,17 +142,23 @@ class PDFDocument extends stream.Readable {
   }
 
   addPage(options) {
-    if (options == null) {
-      ({ options } = this);
-    }
+    const documentOptions = this.options;
 
     // end the current page if needed
-    if (!this.options.bufferPages) {
+    if (!documentOptions.bufferPages) {
       this.flushPages();
     }
 
+    const font = options?.font;
+    if (font) {
+      this.font(font, options.fontFamily);
+    }
+
+    const fontSize = options?.fontSize;
+    if (fontSize) this.fontSize(fontSize);
+
     // create a page object
-    this.page = new PDFPage(this, options);
+    this.page = new PDFPage(this, options || documentOptions);
     this._pageBuffer.push(this.page);
 
     // add the page to the object store

--- a/lib/page.js
+++ b/lib/page.js
@@ -69,7 +69,7 @@ const SIZES = {
 };
 
 class PDFPage {
-  constructor(document, options = {}) {
+  constructor(document, options) {
     this.document = document;
     this._options = options;
     this.size = options.size || 'letter';
@@ -84,22 +84,6 @@ class PDFPage {
     this.height = dimensions[this.layout === 'portrait' ? 1 : 0];
 
     this.content = this.document.ref();
-
-    // `options` defaults to `document.options` (the PDFDocument constructor options) when
-    // addPage() is called without arguments, so it's the same object for every page. Applying
-    // font/fontSize from it unconditionally would silently override any doc.font()/doc.fontSize()
-    // call made since the previous page. Only (re-)apply them here when they were explicitly
-    // passed to this addPage() call, or for the very first page (document.page is still null),
-    // where they're the intended initial default - already applied by initFonts(), so this is
-    // just keeping fontSize/margin calculation below consistent.
-    const isInheritedDefaultOptions = options === document.options;
-    const isFirstPage = document.page == null;
-    if (options.font && (!isInheritedDefaultOptions || isFirstPage)) {
-      document.font(options.font, options.fontFamily);
-    }
-    if (options.fontSize && (!isInheritedDefaultOptions || isFirstPage)) {
-      document.fontSize(options.fontSize);
-    }
 
     // process margins
     // Margin calculation must occur after font assignment to ensure any dynamic sizes are calculated correctly

--- a/lib/page.js
+++ b/lib/page.js
@@ -85,8 +85,21 @@ class PDFPage {
 
     this.content = this.document.ref();
 
-    if (options.font) document.font(options.font, options.fontFamily);
-    if (options.fontSize) document.fontSize(options.fontSize);
+    // `options` defaults to `document.options` (the PDFDocument constructor options) when
+    // addPage() is called without arguments, so it's the same object for every page. Applying
+    // font/fontSize from it unconditionally would silently override any doc.font()/doc.fontSize()
+    // call made since the previous page. Only (re-)apply them here when they were explicitly
+    // passed to this addPage() call, or for the very first page (document.page is still null),
+    // where they're the intended initial default - already applied by initFonts(), so this is
+    // just keeping fontSize/margin calculation below consistent.
+    const isInheritedDefaultOptions = options === document.options;
+    const isFirstPage = document.page == null;
+    if (options.font && (!isInheritedDefaultOptions || isFirstPage)) {
+      document.font(options.font, options.fontFamily);
+    }
+    if (options.fontSize && (!isInheritedDefaultOptions || isFirstPage)) {
+      document.fontSize(options.fontSize);
+    }
 
     // process margins
     // Margin calculation must occur after font assignment to ensure any dynamic sizes are calculated correctly

--- a/tests/unit/page.spec.js
+++ b/tests/unit/page.spec.js
@@ -28,4 +28,34 @@ describe('page', function () {
       expect(page.margins).toEqual({ top: 0, right: 0, bottom: 0, left: 0 });
     });
   });
+
+  // https://github.com/foliojs/pdfkit/issues/1739
+  describe('font persistence across addPage()', function () {
+    test('a font set with doc.font() persists onto a bare addPage() call', function () {
+      const doc = new PDFDocument({ font: 'Helvetica' });
+      doc.font('Helvetica-Bold');
+      doc.addPage();
+      expect(doc._font.name).toBe('Helvetica-Bold');
+    });
+
+    test('a font size set with doc.fontSize() persists onto a bare addPage() call', function () {
+      const doc = new PDFDocument({ font: 'Helvetica' });
+      doc.fontSize(30);
+      doc.addPage();
+      expect(doc._fontSize).toBe(30);
+    });
+
+    test('an explicit font passed to addPage() still overrides the current font', function () {
+      const doc = new PDFDocument({ font: 'Helvetica' });
+      doc.font('Helvetica-Bold');
+      doc.addPage({ font: 'Times-Roman' });
+      expect(doc._font.name).toBe('Times-Roman');
+    });
+
+    test('an explicit fontSize passed to addPage() still applies', function () {
+      const doc = new PDFDocument({ font: 'Helvetica' });
+      doc.addPage({ fontSize: 20 });
+      expect(doc._fontSize).toBe(20);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1739. A font set via `new PDFDocument({ font: 'Helvetica' })` doesn't persist across `addPage()` - any `doc.font()` call made before adding a new page gets silently reverted back to the constructor's default font.

## Root cause

`addPage(options)` defaults to reusing `this.options` (the *exact same* object passed to the `PDFDocument` constructor) whenever it's called without arguments:

```js
addPage(options) {
  if (options == null) {
    ({ options } = this);
  }
  ...
  this.page = new PDFPage(this, options);
```

And `PDFPage`'s constructor unconditionally re-applies `options.font`/`options.fontSize` whenever they're set:

```js
if (options.font) document.font(options.font, options.fontFamily);
if (options.fontSize) document.fontSize(options.fontSize);
```

So a `font` given to the `PDFDocument` constructor gets silently re-applied on *every* subsequent bare `addPage()` call, clobbering whatever font was actually active at that point. (Confirms the reporter's own observation: not setting a default font in the constructor avoids the bug entirely, because then `options.font` is falsy.)

## Fix

`initFonts()` already applies the constructor's default font/fontSize once, before the first page is even created - so `PDFPage` re-deriving them from `options` was only ever load-bearing for two cases:
1. The very first page, where it's a harmless no-op re-application (already correct via `initFonts()`).
2. An explicit `addPage({ font, fontSize })` call - a documented way to override for a specific page (see `docs/getting_started.md`), which must keep working.

Now only applies `options.font`/`options.fontSize` in those two cases, identified by checking whether `options` is the exact object reused from `document.options` (i.e. inherited defaults, not an explicit per-call override) and whether a page already exists (`document.page == null` means this is the first page).

## Test plan
- [x] Added 4 regression tests: font/fontSize persist across a bare `addPage()`, and an explicit `addPage({ font })`/`addPage({ fontSize })` still overrides - covering both the bug and the documented override behavior that must keep working.
- [x] Full test suite passes (380/380).
- [x] `eslint` clean.