### PR TITLE
refactor: decode base64 image data URIs without Buffer

### DIFF
--- a/lib/binary.js
+++ b/lib/binary.js
@@ -12,6 +12,15 @@ export const toBinaryString = (bytes) => {
   return out;
 };
 
+export const fromBase64 = (b64) => {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+};
+
 export const readUInt16BE = (bytes, offset = 0) =>
   ((bytes[offset] << 8) | bytes[offset + 1]) >>> 0;
 

--- a/lib/image.js
+++ b/lib/image.js
@@ -4,6 +4,7 @@ By Devon Govett
 */
 
 import fs from 'fs';
+import { fromBase64 } from './binary';
 import JPEG from './image/jpeg';
 import PNG from './image/png';
 
@@ -17,7 +18,7 @@ class PDFImage {
     } else {
       const match = /^data:.+?;base64,(.*)$/.exec(src);
       if (match) {
-        data = Buffer.from(match[1], 'base64');
+        data = fromBase64(match[1]);
       } else {
         data = fs.readFileSync(src);
         if (!data) {

--- a/lib/image/jpeg.js
+++ b/lib/image/jpeg.js
@@ -99,7 +99,7 @@ class JPEG {
     let marker;
     this.data = data;
     this.label = label;
-    if (this.data.readUInt16BE(0) !== 0xffd8) {
+    if (readUInt16BE(this.data, 0) !== 0xffd8) {
       throw 'SOI not found in JPEG';
     }
 
@@ -112,12 +112,12 @@ class JPEG {
       while (pos < this.data.length && this.data[pos] !== 0xff) pos++;
       if (pos >= this.data.length) break;
 
-      marker = this.data.readUInt16BE(pos);
+      marker = readUInt16BE(this.data, pos);
       pos += 2;
       if (MARKERS.includes(marker)) {
         break;
       }
-      pos += this.data.readUInt16BE(pos);
+      pos += readUInt16BE(this.data, pos);
     }
 
     if (!MARKERS.includes(marker)) {
@@ -126,10 +126,10 @@ class JPEG {
     pos += 2;
 
     this.bits = this.data[pos++];
-    this.height = this.data.readUInt16BE(pos);
+    this.height = readUInt16BE(this.data, pos);
     pos += 2;
 
-    this.width = this.data.readUInt16BE(pos);
+    this.width = readUInt16BE(this.data, pos);
     pos += 2;
 
     const channels = this.data[pos];

--- a/tests/unit/image.spec.js
+++ b/tests/unit/image.spec.js
@@ -1,6 +1,8 @@
 import PDFDocument from '../../lib/document';
 import fs from 'fs';
 import JPEG from '../../lib/image/jpeg';
+import PDFImage from '../../lib/image';
+import dataURIs from '../images/bee';
 
 describe('Image', function () {
   /**
@@ -27,6 +29,12 @@ describe('Image', function () {
     expect(jpeg.width).toBe(375);
     expect(jpeg.height).toBe(500);
     expect(jpeg.orientation).toBe(1);
+  });
+
+  test.each(['png', 'jpeg'])('%s base64 data URI is decoded', (format) => {
+    const image = PDFImage.open(dataURIs[format], 'test');
+    expect(image.width).toBe(409);
+    expect(image.height).toBe(400);
   });
 
   test('RGB JPEG is parsed with DeviceRGB color space (regression)', () => {


### PR DESCRIPTION
Ports the `image.js` / `binary.js` changes from diegomura/react-pdf#3400.

- Adds `fromBase64` to `lib/binary.js` (`atob` + `Uint8Array`), replacing `Buffer.from(match[1], 'base64')` in `PDFImage.open`.
- Switches the JPEG parser's header reads from `this.data.readUInt16BE(...)` to the shared `readUInt16BE` helper it already imports. Without this, the data-URI path throws `this.data.readUInt16BE is not a function`, since the decoded data is now a plain `Uint8Array`.
- Adds a unit test covering both PNG and JPEG data URIs — previously only the JPEG data URI was exercised, and only indirectly through the visual tests.

The PNG magic-byte check from that PR is already on `master`.

`Buffer` is still used elsewhere in `image.js` (`Buffer.isBuffer`, the `ArrayBuffer` branch) and across `security.js` / `object.js` / `virtual-fs.js`, so this removes one usage rather than the dependency.