### PR TITLE
feat: use fflate instead of zlib in the browser build

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -264,7 +264,7 @@ class PDFDocument extends stream.Readable {
   // do nothing, but this method is required by node
 
   _write(data) {
-    if (!Buffer.isBuffer(data)) {
+    if (!(data instanceof Uint8Array)) {
       data = Buffer.from(data + '\n', 'binary');
     }
 

--- a/lib/image/png.js
+++ b/lib/image/png.js
@@ -1,4 +1,4 @@
-import zlib from 'zlib';
+import zlib from '#zlib';
 import PNG from 'png-js';
 
 class PNGImage {
@@ -161,7 +161,7 @@ class PNGImage {
 
       // For interlaced images, re-encode the decoded pixel data
       if (isInterlaced) {
-        this.imgData = zlib.deflateSync(Buffer.from(pixels));
+        this.imgData = zlib.deflateSync(pixels);
       }
 
       this.alphaChannel = zlib.deflateSync(alphaChannel);

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -3,7 +3,7 @@ PDFReference - represents a reference to another object in the PDF object heirar
 By Devon Govett
 */
 
-import zlib from 'zlib';
+import zlib from '#zlib';
 import PDFAbstractReference from './abstract_reference';
 import PDFObject from './object';
 

--- a/lib/zlib/browser.js
+++ b/lib/zlib/browser.js
@@ -1,0 +1,5 @@
+import { zlibSync } from 'fflate';
+
+export default {
+  deflateSync: (data) => zlibSync(data),
+};

--- a/lib/zlib/node.js
+++ b/lib/zlib/node.js
@@ -1,0 +1,5 @@
+import zlib from 'zlib';
+
+export default {
+  deflateSync: (data) => zlib.deflateSync(data),
+};

--- a/package.json
+++ b/package.json
@@ -51,10 +51,11 @@
   "dependencies": {
     "@noble/ciphers": "^1.0.0",
     "@noble/hashes": "^1.6.0",
+    "fflate": "^0.8.3",
     "fontkit": "^2.0.4",
     "js-md5": "^0.8.3",
     "linebreak": "^1.1.0",
-    "png-js": "^1.1.0"
+    "png-js": "^2.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm run build",
@@ -142,6 +143,10 @@
     }
   },
   "imports": {
+    "#zlib": {
+      "node": "./lib/zlib/node.js",
+      "default": "./lib/zlib/browser.js"
+    },
     "#standard-fonts/*": {
       "require": "./js/standard-fonts/*.cjs",
       "default": "./js/standard-fonts/*.mjs"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,6 +6,7 @@ const external = [
   'stream',
   'fs',
   'zlib',
+  'fflate',
   'fontkit',
   'events',
   'linebreak',

--- a/tests/unit/zlib.spec.js
+++ b/tests/unit/zlib.spec.js
@@ -1,0 +1,18 @@
+import zlib from 'zlib';
+import nodeZlib from '../../lib/zlib/node';
+import browserZlib from '../../lib/zlib/browser';
+
+describe('zlib', () => {
+  const data = Buffer.from('PDF FlateDecode stream '.repeat(50), 'binary');
+
+  test.each([
+    ['node', nodeZlib],
+    ['browser', browserZlib],
+  ])('%s deflateSync output inflates back to the input', (_, impl) => {
+    const compressed = impl.deflateSync(data);
+
+    expect(compressed).toBeInstanceOf(Uint8Array);
+    expect(compressed.length).toBeLessThan(data.length);
+    expect(Buffer.from(zlib.inflateSync(compressed))).toEqual(data);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,7 +2797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserify-zlib@npm:^0.2.0, browserify-zlib@npm:~0.2.0":
+"browserify-zlib@npm:~0.2.0":
   version: 0.2.0
   resolution: "browserify-zlib@npm:0.2.0"
   dependencies:
@@ -4026,6 +4026,13 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/e345083c4306b3aed6cb8ec551e26c36bab5c511e99ea4576a16750ddc8d3240e63826cc624f5ae17ad4dc82e68a253213b60d556c11bfad064b7607847ed07f
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.8.2, fflate@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10c0/eab181ca37f5348ae76d4b6f840e0026e30220e33153289ac942222d8b9638237d486507dbcc09878d724095bd354993a2ee48bbee99c8f2c6440d4448719aa7
   languageName: node
   linkType: hard
 
@@ -5867,6 +5874,7 @@ __metadata:
     canvas: "npm:^3.2.3"
     codemirror: "npm:~5.65.21"
     eslint: "npm:^10.4.1"
+    fflate: "npm:^0.8.3"
     fontkit: "npm:^2.0.4"
     gh-pages: "npm:^6.3.0"
     globals: "npm:^17.6.0"
@@ -5876,7 +5884,7 @@ __metadata:
     linebreak: "npm:^1.1.0"
     markdown: "npm:~0.5.0"
     pdfjs-dist: "npm:^5.7.284"
-    png-js: "npm:^1.1.0"
+    png-js: "npm:^2.0.0"
     prettier: "npm:3.4.2"
     pug: "npm:^3.0.4"
     rollup: "npm:^4.61.1"
@@ -5933,12 +5941,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"png-js@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "png-js@npm:1.1.0"
+"png-js@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "png-js@npm:2.0.0"
   dependencies:
-    browserify-zlib: "npm:^0.2.0"
-  checksum: 10c0/61e275cb424b914fbc01c2a1b0096857f214c5fee45054c713dec1ad320760f4dd61f28bb0b3b0c139bd8c49def8891b02ca4018238e7b5f14bb671cd1ca7874
+    fflate: "npm:^0.8.2"
+  checksum: 10c0/69f44790c64b99ca7f44280ed13643e7700bc91406842a096471951227e7dfb52e21924dc3691bf65877c0411d8ced63bebaba1d2da17bf45fefed92a229f1a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Dependency/build change. The browser build imported Node's `zlib` and left the consumer's bundler to shim it, which usually means `browserify-zlib` and `pako`. The two `deflateSync` call sites now import `#zlib`, which resolves to native `zlib` in Node and to fflate's `zlibSync` everywhere else — the same `node`/`default` condition split the rollup builds already use. `png-js` is bumped to v2 (does the same thing internally, API-compatible), so `browserify-zlib` and `pako` are gone from the dependency tree.

fflate returns a plain `Uint8Array` instead of a `Buffer`, so `_write` checks `instanceof Uint8Array` — `Buffer` is a subclass, so nothing changes for existing inputs, and `PDFReference.write` already did this. Checked with the full test suite and by rendering both bundles' output (text + PNG, plain and encrypted) in pdf.js.

**Why fflate rather than browserify-zlib + pako?**

- **No polyfill config.** The browser bundle no longer imports a Node builtin at all. webpack 5 dropped automatic core-module polyfills and Vite never had them, so today `import zlib` either fails the build or silently needs a `resolve.fallback` entry from every user. fflate is just a package.
- **Size.** pdfkit needs exactly one function. Tree-shaken and minified, fflate's `zlibSync` is 6.5 KB (3.2 KB gzipped); pako's deflate is 46.6 KB (14.9 KB gzipped) — it's CJS and doesn't tree-shake. browserify-zlib then layers Node's stream API on top of pako, dragging in `buffer`, `stream`, `util` and `assert` shims for what is a one-shot synchronous call.
- **Output and speed.** On a ~1.9 MB compressible content stream, fflate emitted 16.6 KB against pako's 18.1 KB (~9% smaller) at comparable speed; on already-compressed PNG data it was 9ms against pako's 21ms.
- **Maintenance.** browserify-zlib's last release is 0.2.0 and it pins `pako ~1.0.5`, while pako itself is on 3.x. fflate is ESM-first, typed, and actively released.
- It is also what png-js v2 uses, so image decoding and stream compression now share one compressor instead of two.

Sizes measured with `esbuild --bundle --minify`, timings on Node 22.

**Checklist**:

- [x] Unit Tests
- [ ] Documentation N/A
- [ ] Update CHANGELOG.md
- [x] Ready to be merged

`build-standalone` still browserifies the Node CJS bundle, so that one file keeps pulling `browserify-zlib`. Building it from the browser entry is a separate change.
