### PR TITLE
Fix date text field formatting emitting invalid JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Do not mutate options passed to `doc.annotate()` and its convenience methods (link, note, strike, lineAnnotation, rectAnnotation, ellipseAnnotation, textAnnotation, fileAnnotation)
 - Persist font options when adding a new page. Fixes #1739
 - Use `Uint8Array` instead of Node's `Buffer` internally
+- Fix `date` text field formatting emitting invalid JavaScript, so the format was never applied. Fixes #1546
 
 ### [v0.19.1] - 2026-06-10
 

--- a/lib/mixins/acroform.js
+++ b/lib/mixins/acroform.js
@@ -124,8 +124,11 @@ function mapFormat(options, pdfObject) {
       fnFormat = `AF${format}_Format`;
 
       if (f.type === 'date') {
+        // the Ex variants take the format as a string, where the plain ones
+        // take an index into Acrobat's predefined formats
         fnKeystroke += 'Ex';
-        params = String(f.param);
+        fnFormat += 'Ex';
+        params = '"' + String(f.param) + '"';
       } else if (f.type === 'time') {
         params = String(f.param);
       } else if (f.type === 'number') {

--- a/tests/unit/acroform.spec.js
+++ b/tests/unit/acroform.spec.js
@@ -183,8 +183,8 @@ describe('acroform', () => {
       const expected = [
         '10 0 obj',
         '<<\n/FT /Tx\n/V (1999-12-31)\n/AA <<\n/K <<\n/S /JavaScript\n' +
-          '/JS (AFDate_KeystrokeEx\\(yyyy-mm-dd\\);)\n>>\n' +
-          '/F <<\n/S /JavaScript\n/JS (AFDate_Format\\(yyyy-mm-dd\\);)\n>>\n>>\n' +
+          '/JS (AFDate_KeystrokeEx\\("yyyy-mm-dd"\\);)\n>>\n' +
+          '/F <<\n/S /JavaScript\n/JS (AFDate_FormatEx\\("yyyy-mm-dd"\\);)\n>>\n>>\n' +
           '/T (date)\n/Subtype /Widget\n/F 4\n/Type /Annot\n/Rect [20 752 70 772]\n/Border [0 0 0]\n/C [0 0 0]\n>>',
         'endobj',
       ];
@@ -195,6 +195,31 @@ describe('acroform', () => {
         format: {
           type: 'date',
           param: 'yyyy-mm-dd',
+        },
+      };
+      doc.formText('date', 20, 20, 50, 20, opts);
+      expect(docData.length).toBe(3);
+      expect(docData).toContainChunk(expected);
+    });
+
+    test('date format containing spaces and commas', () => {
+      // an unquoted format is not valid JavaScript, so the viewer
+      // cannot run the action and the field is left unformatted
+      const expected = [
+        '10 0 obj',
+        '<<\n/FT /Tx\n/V (1999-12-31)\n/AA <<\n/K <<\n/S /JavaScript\n' +
+          '/JS (AFDate_KeystrokeEx\\("mmmm d, yyyy"\\);)\n>>\n' +
+          '/F <<\n/S /JavaScript\n/JS (AFDate_FormatEx\\("mmmm d, yyyy"\\);)\n>>\n>>\n' +
+          '/T (date)\n/Subtype /Widget\n/F 4\n/Type /Annot\n/Rect [20 752 70 772]\n/Border [0 0 0]\n/C [0 0 0]\n>>',
+        'endobj',
+      ];
+      doc.initForm();
+      const docData = logData(doc);
+      let opts = {
+        value: '1999-12-31',
+        format: {
+          type: 'date',
+          param: 'mmmm d, yyyy',
         },
       };
       doc.formText('date', 20, 20, 50, 20, opts);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix. Fixes #1546.

The `date` branch of `mapFormat()` passed the format through as a bare token, so the date format example from [the documentation](https://pdfkit.org/docs/forms.html#text_field_formatting) emitted a JavaScript syntax error:

```js
doc.formText('field.date', 10, 60, 200, 40, {
  format: { type: 'date', param: 'mmmm d, yyyy' },
});
```

| emitted | valid JS? |
| --- | --- |
| `AFDate_KeystrokeEx(mmmm d, yyyy);` | no — `missing ) after argument list` |
| `AFDate_Format(mmmm d, yyyy);` | no — `missing ) after argument list` |

The viewer cannot run the action, so nothing formats the field — which matches the report in #1546 that "setting a format doesn't seem to do much".

A format with no spaces hides the problem without avoiding it. `AFDate_KeystrokeEx(yyyy-mm-dd);` parses, but only as a subtraction of three undefined names, so it fails at run time instead of at parse time.

**Fix**

- Quote the format, the same way the `number` and `percent` branches already quote `negStyle` and `currency`.
- Emit `AFDate_FormatEx` to match the `AFDate_KeystrokeEx` that was already being emitted. The `Ex` variants take the format as a string; the plain ones take an index into Acrobat's predefined formats, so the pair was mismatched.

After the fix:

| emitted | valid JS? |
| --- | --- |
| `AFDate_KeystrokeEx("mmmm d, yyyy");` | yes |
| `AFDate_FormatEx("mmmm d, yyyy");` | yes |

`time` is deliberately left alone — its `param` is documented as a number from 0 to 3, so it is correct unquoted.

**Checklist**:

- [x] Unit Tests
- [ ] Documentation — N/A, no API or option change
- [x] Update CHANGELOG.md
- [x] Ready to be merged

Note that this updates the existing `date` test, which asserted the previous output. Adds a second test covering a format containing spaces and a comma, which is the case that was an outright syntax error. Both fail against the current `lib/` and pass with the fix; full unit suite passes, 381/381.
