### PR TITLE
Fix undefined option values serialising as the literal token undefined

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -127,14 +127,25 @@ class PDFObject {
 
       return `(${string})`;
     } else if (Array.isArray(object)) {
+      // Array entries are positional, so an `undefined` hole cannot simply be
+      // dropped without shifting everything after it. `null` is a real PDF
+      // object (ISO 32000-1, 7.3.9) and is the closest valid stand-in, which
+      // is also what JSON.stringify does.
       const items = object
-        .map((e) => PDFObject.convert(e, encryptFn))
+        .map((e) => PDFObject.convert(e === undefined ? null : e, encryptFn))
         .join(' ');
       return `[${items}]`;
     } else if ({}.toString.call(object) === '[object Object]') {
       const out = ['<<'];
       for (let key in object) {
         const val = object[key];
+        // `undefined` has no PDF representation, so serialising it produced the
+        // literal token `undefined` and an unparseable file. The spec treats a
+        // dictionary entry whose value is null as absent (ISO 32000-1, 7.3.9),
+        // so omitting the key is the closest valid equivalent - and it matches
+        // JSON.stringify. An explicit `null` is left alone: it is a real PDF
+        // object and callers may be relying on it.
+        if (val === undefined) continue;
         out.push(`/${key} ${PDFObject.convert(val, encryptFn)}`);
       }
 

--- a/tests/unit/object.spec.js
+++ b/tests/unit/object.spec.js
@@ -19,6 +19,20 @@ describe('PDFObject', () => {
       expect(result.length).toEqual(12);
       expect(result).toMatchInlineSnapshot(`"(þÿ±²³´)"`);
     });
+
+    test('dictionary omits keys whose value is undefined', () => {
+      expect(PDFObject.convert({ a: 1, b: undefined, c: 2 })).toEqual(
+        '<<\n/a 1\n/c 2\n>>',
+      );
+    });
+
+    test('dictionary keeps an explicit null', () => {
+      expect(PDFObject.convert({ a: null })).toEqual('<<\n/a null\n>>');
+    });
+
+    test('array converts an undefined entry to null to keep positions', () => {
+      expect(PDFObject.convert([1, undefined, 2])).toEqual('[1 null 2]');
+    });
   });
 
   describe('escapeName', () => {


### PR DESCRIPTION
Fixes #1735.

### The bug

`PDFObject.convert` has no case for `undefined`, so it falls through to the
generic `${object}` branch and writes the literal token into the file:

```js
PDFObject.convert({ a: 1, b: undefined, c: 2 });  // <<\n/a 1\n/b undefined\n/c 2\n>>
PDFObject.convert([1, undefined, 2]);             // [1 undefined 2]
```

That is not parseable PDF. Viewers tend to skip over it, parsers do not — #1735
reports iText RUPS throwing an NPE and pdf-lib failing with
`Expected instance of PDFDict, but got instance of PDFInvalidObject`.

The specific example in #1735 no longer reproduces, since `annotate()` was
refactored, but the underlying problem is still reachable through any annotation
option:

```js
doc.annotate(10, 10, 100, 20, { Subtype: 'Text', Foo: undefined });   // /Foo undefined
doc.link(10, 10, 100, 20, 'https://example.com', { Foo: undefined }); // /Foo undefined
```

### The fix

Handled in the serialiser rather than in `annotate`, so every dictionary is
covered rather than only the path this issue happened to surface.

- **Dictionaries** — the key is omitted. ISO 32000-1, 7.3.9 defines an entry
  whose value is null as equivalent to the entry being absent, so dropping the
  key is the closest valid equivalent. It is also what `JSON.stringify` does.
- **Arrays** — the entry becomes `null`. Array positions are meaningful, so
  removing a hole would shift every following entry; `null` is a real PDF object
  and keeps the indices intact. Again matching `JSON.stringify`.
- **An explicit `null` is left exactly as it was.** It is valid PDF and callers
  may be relying on it. There is a test pinning this so it cannot regress.

### Testing

Three tests added to `tests/unit/object.spec.js`. Two of them fail without the
change:

```
expected '<<\n/a 1\n/b undefined\n/c 2\n>>' to deeply equal '<<\n/a 1\n/c 2\n>>'
expected '[1 undefined 2]' to deeply equal '[1 null 2]'
```

The third (explicit `null` preserved) passes both before and after, which is the
point of it.

Full unit suite passes: 388/388. eslint and prettier clean.

Reported by @baltpeter, who also proposed the first patch.
