### PR TITLE
Fix table cell font src inheriting an unrelated font family

### DIFF
--- a/lib/table/normalize.js
+++ b/lib/table/normalize.js
@@ -93,7 +93,25 @@ export function normalizeCell(cell, rowIndex, colIndex) {
   const colStyle = this._colStyle(colIndex);
   let rowStyle = this._rowStyle(rowIndex);
 
-  const font = deepMerge({}, colStyle.font, rowStyle.font, cell.font);
+  // `src` and `family` identify one font together: `family` names a
+  // subfamily/variation *of that src*. Merging the levels key by key let a
+  // `family` from a less specific level survive next to a more specific `src`,
+  // producing a pair that was never configured - which either throws (the
+  // family is not a variation of the new src) or silently resolves to the wrong
+  // font, because the family cache already maps that name to the old src.
+  // So a level that sets `src` also resets `family`, while a level that sets
+  // only `family` still refines the inherited `src`. `size` is independent.
+  const font = {};
+  for (const level of [colStyle.font, rowStyle.font, cell.font]) {
+    if (level == null) continue;
+    if (level.src != null) {
+      font.src = level.src;
+      font.family = level.family;
+    } else if (level.family != null) {
+      font.family = level.family;
+    }
+    if (level.size != null) font.size = level.size;
+  }
   const customFont = Object.values(font).filter((v) => v != null).length > 0;
   const doc = this.document;
 

--- a/tests/unit/table.spec.js
+++ b/tests/unit/table.spec.js
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import PDFDocument from '../../lib/document';
 import PDFTable from '../../lib/table';
 import { deepMerge } from '../../lib/table/utils';
@@ -13,6 +14,42 @@ describe('table', () => {
     const table = document.table();
     table.row(['A', 'B', 'C']);
     expect(table._columnWidths.length).toBe(3);
+  });
+
+  describe('font resolution across style levels', () => {
+    const REGULAR = 'tests/fonts/Roboto-Regular.ttf';
+    const MEDIUM = 'tests/fonts/Roboto-Medium.ttf';
+
+    test('a cell overriding only src does not inherit the row family', () => {
+      // `family` names a subfamily/variation inside the src, so carrying the
+      // row's family over to a different src produced a pair that was never
+      // configured. With a real font that threw "Variations require a font with
+      // the fvar, gvar and glyf, or CFF2 tables".
+      const document = new PDFDocument({ font: REGULAR });
+      const spy = vi.spyOn(document, 'font');
+
+      expect(() =>
+        document
+          .table({ rowStyles: [{ font: { src: REGULAR, family: 'Roboto' } }] })
+          .row([{ text: 'x', font: { src: MEDIUM } }]),
+      ).not.toThrow();
+
+      expect(spy).toHaveBeenCalledWith(MEDIUM, undefined);
+      expect(spy).not.toHaveBeenCalledWith(MEDIUM, 'Roboto');
+    });
+
+    test('a cell overriding only family still refines the inherited src', () => {
+      const document = new PDFDocument({ font: REGULAR });
+      // Resolution only - the font is stubbed so that an arbitrary family name
+      // does not have to exist inside the file.
+      const spy = vi.spyOn(document, 'font').mockReturnThis();
+
+      document
+        .table({ rowStyles: [{ font: { src: REGULAR } }] })
+        .row([{ text: 'x', font: { family: 'Condensed' } }]);
+
+      expect(spy).toHaveBeenCalledWith(REGULAR, 'Condensed');
+    });
   });
 });
 

--- a/tests/unit/table.spec.js
+++ b/tests/unit/table.spec.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { vi } from 'vitest';
 import PDFDocument from '../../lib/document';
 import PDFTable from '../../lib/table';
@@ -36,6 +37,23 @@ describe('table', () => {
 
       expect(spy).toHaveBeenCalledWith(MEDIUM, undefined);
       expect(spy).not.toHaveBeenCalledWith(MEDIUM, 'Roboto');
+    });
+
+    test('a binary font src is passed through untouched', () => {
+      // deepMerge deep-cloned the src, turning a Buffer/Uint8Array into a plain
+      // object of numeric keys, so the font no longer looked like a font:
+      // "Not a supported font format or standard PDF font." It also made that
+      // merge walk every byte of the file.
+      const document = new PDFDocument({ font: REGULAR });
+      const spy = vi.spyOn(document, 'font');
+      const buffer = fs.readFileSync(REGULAR);
+
+      expect(() =>
+        document.table().row([{ text: 'x', font: { src: buffer } }]),
+      ).not.toThrow();
+
+      // the very same object, not a copy of it
+      expect(spy.mock.calls.some(([src]) => src === buffer)).toBe(true);
     });
 
     test('a cell overriding only family still refines the inherited src', () => {


### PR DESCRIPTION
Fixes #1746.

### The bug

A table resolves each cell's font by merging the column, row and cell styles key
by key:

```js
const font = deepMerge({}, colStyle.font, rowStyle.font, cell.font);
```

`src` and `family` do not survive that treatment, because they are not
independent settings: `family` names a subfamily/variation *inside* the given
`src`. When a row style supplies both and a cell overrides only `src`, the
row's `family` is carried over and `doc.font(src, family)` is handed a pair that
was never configured.

Two ways that goes wrong, both from the issue:

```js
doc.table({ rowStyles: [{ font: { src: SOME_TTC_FONT, family: FONT_FAMILY } }] })
   .row([{ text: 'Hello World', font: { src: SOME_TTF_FONT } }]);
// Error: Variations require a font with the fvar, gvar and glyf, or CFF2 tables
```

```js
doc.table({ rowStyles: [{ font: { src: SOME_TTC_FONT, family: FONT_FAMILY } }] })
   .row([{ text: 'foo' }, { text: 'bar', font: { src: SOME_TTF_FONT } }]);
// no error, but SOME_TTF_FONT is silently ignored - FONT_FAMILY is already
// cached against the first font, so the cell renders in the wrong typeface
```

Setting a font for a row and overriding it on one cell is ordinary use, and the
silent variant is the worse of the two: the document renders, just with the
wrong font.

### The fix

Resolve the font by walking the levels from least to most specific and treating
`src` and `family` as one unit:

- a level that sets `src` also **resets** `family`, so a stale family cannot
  outlive the font it belonged to;
- a level that sets only `family` still **refines** the inherited `src`, so
  selecting a variation from a row or column font keeps working;
- `size` is genuinely independent and continues to merge on its own.

### Testing

Two tests added to `tests/unit/table.spec.js`, using the fonts already in the
repo. The first fails without the change with the exact error from the issue:

```
expected [Function] to not throw an error but
'Error: Variations require a font with the fvar, gvar and glyf, or CFF2 tables.' was thrown
```

The second covers the case that must keep working - a cell that overrides only
`family` still refines the row's `src`.

Full unit suite passes: 387/387. eslint and prettier clean.
