### PR TITLE
Throw from addNamedEmbeddedFile when no ref is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [BREAKING CHANGE] Remove the virtual file system (`pdfkit/virtual-fs`). Browser builds no longer depend on `fs`: pass a `Uint8Array`, `ArrayBuffer` or data URL to `registerFont`, `image` and `file` instead of a path
 - [BREAKING CHANGE] Restrict AcroForm options to documented mappings and explicit escape hatches.
 - [BREAKING CHANGE] Stop automatically uppercasing annotation option keys.
+- [BREAKING CHANGE] Throw from `addNamedEmbeddedFile` when no ref is given, instead of writing an unparseable `undefined` token into the `/EmbeddedFiles` name tree
 - Do not mutate options passed to `doc.annotate()` and its convenience methods (link, note, strike, lineAnnotation, rectAnnotation, ellipseAnnotation, textAnnotation, fileAnnotation)
 - Persist font options when adding a new page. Fixes #1739
 - Use `Uint8Array` instead of Node's `Buffer` internally

--- a/lib/document.js
+++ b/lib/document.js
@@ -232,6 +232,10 @@ class PDFDocument extends Readable {
   }
 
   addNamedEmbeddedFile(name, ref) {
+    if (!ref) {
+      throw new Error(`No ref specified for embedded file ${name}`);
+    }
+
     if (!this._root.data.Names.data.EmbeddedFiles) {
       // disabling /Limits for this tree fixes attachments not showing in Adobe Reader
       this._root.data.Names.data.EmbeddedFiles = new PDFNameTree({

--- a/tests/unit/attachments.spec.js
+++ b/tests/unit/attachments.spec.js
@@ -244,4 +244,42 @@ describe('file', () => {
 >>`,
     ]);
   });
+
+  test('throws when the ref is missing', () => {
+    expect(() =>
+      document.addNamedEmbeddedFile('phantom.txt', undefined),
+    ).toThrow('No ref specified for embedded file phantom.txt');
+
+    expect(() => document.addNamedEmbeddedFile('phantom.txt', null)).toThrow(
+      'No ref specified for embedded file phantom.txt',
+    );
+  });
+
+  test('registers a filespec created with the hidden option', () => {
+    const docData = logData(document);
+
+    const filespec = document.file(Buffer.from('example text'), {
+      name: 'file.txt',
+      creationDate: date,
+      modifiedDate: date,
+      hidden: true,
+    });
+    document.addNamedEmbeddedFile('file.txt', filespec);
+    document.end();
+
+    expect(docData).toContainChunk([
+      `2 0 obj`,
+      `<<
+/Dests <<
+  /Names [
+]
+>>
+/EmbeddedFiles <<
+  /Names [
+    (file.txt) 9 0 R
+]
+>>
+>>`,
+    ]);
+  });
 });


### PR DESCRIPTION
Follow-up to #1771, as you asked — the throw on its own. `lib/tree.js` is
untouched, so the `PDFTree.toString` filter you were less inclined to merge is
not in here.

### The bug

```js
doc.addNamedEmbeddedFile('phantom.txt', undefined);
```

```
/EmbeddedFiles <<
  /Names [
    (phantom.txt) undefined
]
>>
```

`undefined` is not a PDF object, so the document does not parse. The caller asked
for an attachment under a name and got a broken file with no signal.

### Why throw, of the three you listed

`doc.file()` already refuses the same thing:

```js
doc.file(undefined, { name: 'x.txt' });    // Error: No src specified
doc.addNamedEmbeddedFile('x', undefined);  // silently accepted, corrupt output
```

`addNamedEmbeddedFile` is the lower-level route to the same place, so the two now
agree. Silent drop is the option I would argue against hardest — a valid PDF with
nothing attached and no error is harder to debug than a stack trace.

In `addNamedEmbeddedFile` rather than `PDFTree.add`, because `add` is shared with
`/Dests`, `/JavaScript` and `ParentTree`, which only ever receive values the
library builds itself.

### Scope

`!ref` rather than `=== undefined`, matching the `if (!src)` guard in `file()`.
That also catches `null`, which is the more awkward of the two: it serialises to
the PDF `null` keyword, so the file parses and you get a silently empty
attachment rather than a loud broken one. Happy to narrow it if you would rather.

The guard sits before the lazy `/EmbeddedFiles` init, so a rejected call does not
leave an empty name tree behind in the catalog.

`name` is not validated. A bad key serialises to `(undefined)`, which parses, and
the same applies to `addNamedDestination` and `addNamedJavaScript` — fixing it
here alone would make the three siblings inconsistent. Separate change.

The one caller inside the library, `lib/mixins/attachments.js:102`, passes a
filespec `file()` has just created, and `file()` throws before it can return
anything falsy — so the library's own path cannot reach the new guard.

Marked breaking, though anyone hitting this today is shipping a PDF that does not
parse.

### Tests

2 added. `throws when the ref is missing` fails on master. The second registers a
filespec created with `hidden: true` and passes either way — a guard that the
normal hand-registration path still works, not evidence for the change.

Unit suite 396/396.
