### PR TITLE
Fix CI after dev dependency update

### DIFF
--- a/lib/font/embedded.js
+++ b/lib/font/embedded.js
@@ -185,7 +185,7 @@ class EmbeddedFont extends PDFFont {
       const cidSetBuffer = new Uint8Array(Math.ceil((maxCID + 1) / 8));
       for (let cid = 0; cid <= maxCID; cid++) {
         if (this.widths[cid] != null) {
-          cidSetBuffer[Math.floor(cid / 8)] |= 0x80 >> cid % 8;
+          cidSetBuffer[Math.floor(cid / 8)] |= 0x80 >> (cid % 8);
         }
       }
       const CIDSetRef = this.document.ref();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jest-diff": "^30.4.1",
     "jest-image-snapshot": "^6.5.2",
     "markdown": "~0.5.0",
-    "pdfjs-dist": "^6.2.108",
+    "pdfjs-dist": "^5.7.284",
     "prettier": "3.9.6",
     "pug": "^3.0.4",
     "rollup": "^4.62.4",

--- a/tests/unit/pdfa1.spec.js
+++ b/tests/unit/pdfa1.spec.js
@@ -144,7 +144,7 @@ describe('PDF/A-1', () => {
     const CIDSet = Buffer.alloc(Math.ceil((maxCID + 1) / 8), 0);
     for (let cid = 0; cid <= maxCID; cid++) {
       if (widths[cid] != null) {
-        CIDSet[Math.floor(cid / 8)] |= 0x80 >> cid % 8;
+        CIDSet[Math.floor(cid / 8)] |= 0x80 >> (cid % 8);
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,98 +1552,98 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-android-arm64@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-android-arm64@npm:1.0.6"
+"@napi-rs/canvas-android-arm64@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-android-arm64@npm:0.1.100"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-arm64@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-darwin-arm64@npm:1.0.6"
+"@napi-rs/canvas-darwin-arm64@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-darwin-arm64@npm:0.1.100"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-darwin-x64@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-darwin-x64@npm:1.0.6"
+"@napi-rs/canvas-darwin-x64@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-darwin-x64@npm:0.1.100"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm-gnueabihf@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:1.0.6"
+"@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-linux-arm-gnueabihf@npm:0.1.100"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-gnu@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:1.0.6"
+"@napi-rs/canvas-linux-arm64-gnu@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-linux-arm64-gnu@npm:0.1.100"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-arm64-musl@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:1.0.6"
+"@napi-rs/canvas-linux-arm64-musl@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-linux-arm64-musl@npm:0.1.100"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-riscv64-gnu@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:1.0.6"
+"@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-linux-riscv64-gnu@npm:0.1.100"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-gnu@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:1.0.6"
+"@napi-rs/canvas-linux-x64-gnu@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-linux-x64-gnu@npm:0.1.100"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-linux-x64-musl@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-linux-x64-musl@npm:1.0.6"
+"@napi-rs/canvas-linux-x64-musl@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-linux-x64-musl@npm:0.1.100"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-arm64-msvc@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-win32-arm64-msvc@npm:1.0.6"
+"@napi-rs/canvas-win32-arm64-msvc@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-win32-arm64-msvc@npm:0.1.100"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas-win32-x64-msvc@npm:1.0.6":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:1.0.6"
+"@napi-rs/canvas-win32-x64-msvc@npm:0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas-win32-x64-msvc@npm:0.1.100"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/canvas@npm:^1.0.0":
-  version: 1.0.6
-  resolution: "@napi-rs/canvas@npm:1.0.6"
+"@napi-rs/canvas@npm:^0.1.100":
+  version: 0.1.100
+  resolution: "@napi-rs/canvas@npm:0.1.100"
   dependencies:
-    "@napi-rs/canvas-android-arm64": "npm:1.0.6"
-    "@napi-rs/canvas-darwin-arm64": "npm:1.0.6"
-    "@napi-rs/canvas-darwin-x64": "npm:1.0.6"
-    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:1.0.6"
-    "@napi-rs/canvas-linux-arm64-gnu": "npm:1.0.6"
-    "@napi-rs/canvas-linux-arm64-musl": "npm:1.0.6"
-    "@napi-rs/canvas-linux-riscv64-gnu": "npm:1.0.6"
-    "@napi-rs/canvas-linux-x64-gnu": "npm:1.0.6"
-    "@napi-rs/canvas-linux-x64-musl": "npm:1.0.6"
-    "@napi-rs/canvas-win32-arm64-msvc": "npm:1.0.6"
-    "@napi-rs/canvas-win32-x64-msvc": "npm:1.0.6"
+    "@napi-rs/canvas-android-arm64": "npm:0.1.100"
+    "@napi-rs/canvas-darwin-arm64": "npm:0.1.100"
+    "@napi-rs/canvas-darwin-x64": "npm:0.1.100"
+    "@napi-rs/canvas-linux-arm-gnueabihf": "npm:0.1.100"
+    "@napi-rs/canvas-linux-arm64-gnu": "npm:0.1.100"
+    "@napi-rs/canvas-linux-arm64-musl": "npm:0.1.100"
+    "@napi-rs/canvas-linux-riscv64-gnu": "npm:0.1.100"
+    "@napi-rs/canvas-linux-x64-gnu": "npm:0.1.100"
+    "@napi-rs/canvas-linux-x64-musl": "npm:0.1.100"
+    "@napi-rs/canvas-win32-arm64-msvc": "npm:0.1.100"
+    "@napi-rs/canvas-win32-x64-msvc": "npm:0.1.100"
   dependenciesMeta:
     "@napi-rs/canvas-android-arm64":
       optional: true
@@ -1671,7 +1671,7 @@ __metadata:
       built: true
     skia-canvas:
       built: true
-  checksum: 10c0/652ab1b41124aa637149d7801a5be2a9e8a5cfda1f9f43b28d48eb4eaa044020496c938fe439634b14e4ac74bb1fdc8eb5938c511db13e965cca40b25e164c2c
+  checksum: 10c0/d3dfca5620a41c34addd344bd4c448a5334d3f32f2562ec8390507b3897747ed1de9f08fcb9169cff6dd27111afb5b3eaf7e42cc1494c8fa4128e7d4235f6bea
   languageName: node
   linkType: hard
 
@@ -5496,15 +5496,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfjs-dist@npm:^6.2.108":
-  version: 6.2.108
-  resolution: "pdfjs-dist@npm:6.2.108"
+"pdfjs-dist@npm:^5.7.284":
+  version: 5.7.284
+  resolution: "pdfjs-dist@npm:5.7.284"
   dependencies:
-    "@napi-rs/canvas": "npm:^1.0.0"
+    "@napi-rs/canvas": "npm:^0.1.100"
   dependenciesMeta:
     "@napi-rs/canvas":
       optional: true
-  checksum: 10c0/12cf7d9e549339f716c6cb33ca89b85774067616d1aea959f6b96740a489f8d9906b42f5add5d9c2118e25f3a457126e68f490c273184689b7e714718b5293e0
+  checksum: 10c0/5ff7678e9b197acb90b22329753c11e45dbb862d8e1d721e311fc13d5cfab4f6b87114d75307b5db8b057e25c732226ef0a9feff89dbb1f2bbc3ef362ca649af
   languageName: node
   linkType: hard
 
@@ -5533,7 +5533,7 @@ __metadata:
     jest-image-snapshot: "npm:^6.5.2"
     linebreak: "npm:^1.1.0"
     markdown: "npm:~0.5.0"
-    pdfjs-dist: "npm:^6.2.108"
+    pdfjs-dist: "npm:^5.7.284"
     png-js: "npm:^2.0.0"
     prettier: "npm:3.9.6"
     pug: "npm:^3.0.4"


### PR DESCRIPTION
ea51c47 (Update dev dependencies) broke CI in two ways. Since the workflow only runs on pull requests, master went red silently and every open PR currently fails.

- prettier was bumped without reformatting, so `lib/font/embedded.js` and `tests/unit/pdfa1.spec.js` fail `npm run prettier -- --check`. Reformatted (2 lines).
- pdfjs-dist was bumped to ^6, which uses `ArrayBuffer.prototype.transferToFixedLength` — a Node 21+ API — so all visual tests fail on the Node 20 job. Pinned back to ^5 since the package still supports Node 20 (`engines`) and pdfjs-dist is only a devDependency used to render visual-test snapshots. It can move to ^6 whenever the Node requirement is raised to 22+.

Full suite (520 tests including visual) verified locally on Node 20.