### PR TITLE
feat: add Node ESM build: route the node import condition to a real Node bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Add a Node ESM build so `import 'pdfkit'` in Node resolves to the Node build (real file system, native zlib, Node streams, self-registering standard fonts) instead of the browser bundle
 - [BREAKING CHANGE] Remove the virtual file system (`pdfkit/virtual-fs`). Browser builds no longer depend on `fs`: use `registerFile` to register `Uint8Array` data under a path, pass a `Uint8Array` or `ArrayBuffer` directly to `registerFont`, `image` and `file`, or pass a data URL directly to `image` and `file`
 - Add `registerFile(path, data, options)` to globally register in-memory files in Node and browsers, with optional `birthtime` and `ctime` metadata. Passing `undefined` as data unregisters the path
 - [BREAKING CHANGE] Export `PDFDocument`, `LineWrapper` and `registerFile` as named exports from the main Node and browser entry points while preserving the default `PDFDocument` export

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,7 +15,15 @@ export and create an instance of the class.
     const { PDFDocument } = require('pdfkit');
     const doc = new PDFDocument();
 
-Both `const PDFDocument = require('pdfkit')` and
+Or, from an ES module:
+
+    import { PDFDocument } from 'pdfkit';
+    const doc = new PDFDocument();
+
+In Node, both `require('pdfkit')` and `import 'pdfkit'` resolve to a Node build
+with real file system access, native zlib compression and Node streams; browsers
+and bundlers targeting browsers get the browser build described below. Both
+`const PDFDocument = require('pdfkit')` and
 `import PDFDocument from 'pdfkit'` remain supported for backward compatibility.
 New code should prefer the named `PDFDocument` export, which will make a future
 migration to an ESM-only package more straightforward.
@@ -122,7 +130,7 @@ Registration is global to the loaded PDFKit module. Registering the same path
 again replaces its bytes. Passing `undefined` unregisters the path and does
 nothing if it was not registered. Unregistered paths throw in browsers.
 
-The same registry is available from the CommonJS entry point in Node. Registered
+The same registry is available from the Node entry points. Registered
 data takes precedence over a file at the same path; unregistering restores normal
 file system lookup.
 

--- a/lib/document.node.js
+++ b/lib/document.node.js
@@ -1,7 +1,10 @@
+import { createRequire } from 'module';
 import PDFDocument from './document';
 import LineWrapper from './line_wrapper';
 import { registerStdFontLoaders } from './font/standard_fonts';
 import { registerFile } from '#fs';
+
+const require = createRequire(import.meta.url);
 
 registerStdFontLoaders({
   Courier: () => require('#standard-fonts/Courier'),

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prettier": "prettier --check lib tests docs tools",
     "format": "prettier --write lib tests docs tools",
     "test": "vitest --testTimeout 8000 run --exclude \"tests/tools/**\"",
-    "test:package": "node tests/package-resolution.cjs",
+    "test:package": "node tests/package-resolution.cjs && node tests/package-resolution.mjs",
     "test:tools": "vitest --testTimeout 8000 run tests/tools",
     "test:visual": "vitest --testTimeout 8000 run tests/visual",
     "test:unit": "vitest run tests/unit"
@@ -75,6 +75,7 @@
   "exports": {
     ".": {
       "node": {
+        "import": "./js/pdfkit.node.mjs",
         "require": "./js/pdfkit.js"
       },
       "default": "./js/pdfkit.browser.mjs"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,6 +6,7 @@ import binary from './tools/binary-plugin.mjs';
 const iccProfilePath = 'lib/mixins/data/sRGB_IEC61966_2_1.icc';
 
 const external = [
+  'module',
   'stream',
   'fs',
   'zlib',
@@ -72,20 +73,27 @@ const browserPlugins = () => [
 ];
 
 export default [
-  // CommonJS build for Node
+  // CommonJS and ES builds for Node
   {
     input: 'lib/document.node.js',
     external,
-    output: {
-      name: 'pdfkit',
-      file: 'js/pdfkit.js',
-      format: 'cjs',
-      sourcemap: true,
-      interop: 'default',
-      exports: 'named',
-      footer:
-        'module.exports = exports.default;\nmodule.exports.PDFDocument = exports.PDFDocument;\nmodule.exports.LineWrapper = exports.LineWrapper;\nmodule.exports.registerFile = exports.registerFile;',
-    },
+    output: [
+      {
+        name: 'pdfkit',
+        file: 'js/pdfkit.js',
+        format: 'cjs',
+        sourcemap: true,
+        interop: 'default',
+        exports: 'named',
+        footer:
+          'module.exports = exports.default;\nmodule.exports.PDFDocument = exports.PDFDocument;\nmodule.exports.LineWrapper = exports.LineWrapper;\nmodule.exports.registerFile = exports.registerFile;',
+      },
+      {
+        file: 'js/pdfkit.node.mjs',
+        format: 'es',
+        sourcemap: true,
+      },
+    ],
     plugins: [
       asset(iccProfilePath, 'data/sRGB_IEC61966_2_1.icc'),
       nodeResolve({

--- a/tests/package-resolution.cjs
+++ b/tests/package-resolution.cjs
@@ -12,6 +12,9 @@ const emittedIccPath = path.resolve(
 );
 const nodeBundlePath = require.resolve('pdfkit');
 const browserBundlePath = path.resolve(__dirname, '../js/pdfkit.browser.js');
+const browserEsBundleUrl = require('node:url').pathToFileURL(
+  path.resolve(__dirname, '../js/pdfkit.browser.mjs'),
+);
 const outputHelpers = require('pdfkit/output');
 const sourceIcc = fs.readFileSync(sourceIccPath);
 
@@ -80,7 +83,13 @@ assert.equal(BrowserPDFDocument.registerFile, undefined);
   nodeDocument.end();
   assert.ok((await nodeOutput) instanceof Uint8Array);
 
-  const browserModule = await import('pdfkit');
+  const nodeEsModule = await import('pdfkit');
+  assert.equal(typeof nodeEsModule.default, 'function');
+  assert.equal(nodeEsModule.PDFDocument, nodeEsModule.default);
+  assert.equal(typeof nodeEsModule.LineWrapper, 'function');
+  assert.equal(typeof nodeEsModule.registerFile, 'function');
+
+  const browserModule = await import(browserEsBundleUrl);
   const browserOutputHelpers = await import('pdfkit/output');
 
   assert.equal(typeof browserModule.default, 'function');

--- a/tests/package-resolution.mjs
+++ b/tests/package-resolution.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import PDFDocument, { LineWrapper, registerFile } from 'pdfkit';
+import { toBytes } from 'pdfkit/output';
+
+const require = createRequire(import.meta.url);
+
+assert.equal(
+  import.meta.resolve('pdfkit'),
+  new URL('../js/pdfkit.node.mjs', import.meta.url).href,
+);
+
+assert.equal(typeof PDFDocument, 'function');
+assert.equal(PDFDocument.name, 'PDFDocument');
+assert.equal(typeof LineWrapper, 'function');
+assert.equal(typeof registerFile, 'function');
+assert.equal(PDFDocument.LineWrapper, undefined);
+assert.equal(PDFDocument.registerFile, undefined);
+
+const loadedStandardFontModules = () =>
+  Object.keys(require.cache).filter((file) =>
+    file.includes('js/standard-fonts'),
+  );
+
+assert.deepEqual(loadedStandardFontModules(), []);
+
+const helveticaDocument = new PDFDocument();
+const helveticaOutput = toBytes(helveticaDocument);
+helveticaDocument.text('Standard fonts self-register in the node ESM build');
+helveticaDocument.end();
+assert.ok((await helveticaOutput) instanceof Uint8Array);
+assert.ok(
+  loadedStandardFontModules().some((file) => file.endsWith('Helvetica.cjs')),
+);
+assert.equal(
+  loadedStandardFontModules().some(
+    (file) => file.includes('Courier') || file.includes('TimesRoman'),
+  ),
+  false,
+);
+
+const fileDocument = new PDFDocument();
+const fileOutput = toBytes(fileDocument);
+fileDocument.font(
+  fileURLToPath(new URL('fonts/Roboto-Regular.ttf', import.meta.url)),
+);
+fileDocument.text('The node build reads files from the real file system');
+fileDocument.image(fileURLToPath(new URL('images/bee.png', import.meta.url)), {
+  width: 100,
+});
+fileDocument.end();
+assert.ok((await fileOutput) instanceof Uint8Array);


### PR DESCRIPTION
## Problem

The root export map only defines `require` under the `node` condition:

```json
".": {
  "node": { "require": "./js/pdfkit.js" },
  "default": "./js/pdfkit.browser.mjs"
}
```

When a Node ESM consumer does `import PDFDocument from 'pdfkit'`, the nested `node` object has no matching key, so resolution falls through to `"default"` — and modern Node users silently get the **browser** build. On Node that means:

- Virtual fs instead of real fs: path-based APIs (`doc.image('/path.png')`, `doc.font('/path.ttf')`, `doc.file('/path')`) fail unless the file was pre-registered with `registerFile`.
- fflate's pure-JS `zlibSync` instead of native `zlib.deflateSync` for every content stream (a measurable perf regression on large documents).
- The custom browser `Readable` shim instead of Node streams.
- Standard fonts are not self-registering (the browser build expects the consumer to call `registerStdFonts`).

Nothing guarded this: `tests/package-resolution.cjs` only exercises `require('pdfkit')`. (Extra context: react-pdf is converging onto upstream pdfkit and is a pure-ESM consumer, so it currently lands on the browser build in Node.)

## Change

Add a Node ESM bundle (`js/pdfkit.node.mjs`) and wire it into the export map:

```json
".": {
  "node": {
    "import": "./js/pdfkit.node.mjs",
    "require": "./js/pdfkit.js"
  },
  "default": "./js/pdfkit.browser.mjs"
}
```

- The ESM bundle is a second output of the existing `lib/document.node.js` rollup entry, sharing its plugins, externals and babel config. `#fs`/`#zlib`/`#stream` are inlined via the `node` condition exactly as in the CJS bundle, with `fs`/`zlib`/`stream` external.
- `lib/document.node.js` now gets its `require` from `createRequire(import.meta.url)` so the lazy standard-font loaders work in both output formats (rollup shims `import.meta.url` in the CJS output; the AFM data modules are still only loaded when a standard font is actually used).
- Browsers/bundlers are unaffected: they don't match the `node` condition and keep resolving to `js/pdfkit.browser.mjs` via `"default"`.

## Tests

New `tests/package-resolution.mjs`, wired into `npm run test:package`:

- Asserts `import.meta.resolve('pdfkit')` points at `js/pdfkit.node.mjs`.
- Proves it's the Node build functionally: loads a font and an image **by file path** and ends the document cleanly (this fails on the browser build's virtual fs — verified).
- Proves standard fonts self-register: a default-Helvetica document with text ends cleanly.
- Proves laziness is kept: after using only Helvetica, no other standard-font data module is in the require cache.

`tests/package-resolution.cjs` previously used `await import('pdfkit')` to reach the browser bundle (the misresolution this PR fixes); it now asserts the dynamic import yields the Node ESM build and loads the browser ESM bundle directly by path to keep its coverage.

`npm test` (481 tests), `npm run test:tools`, `npm run lint` and `npm run prettier` all pass.
