### PR TITLE
Fix case-insensitive lookup for named CSS colors

### DIFF
--- a/lib/mixins/color.js
+++ b/lib/mixins/color.js
@@ -26,8 +26,8 @@ export default {
         }
         const hex = parseInt(color.slice(1), 16);
         color = [hex >> 16, (hex >> 8) & 0xff, hex & 0xff];
-      } else if (namedColors[color]) {
-        color = namedColors[color];
+      } else if (namedColors[color.toLowerCase()]) {
+        color = namedColors[color.toLowerCase()];
       } else if (this.spotColors[color]) {
         return this.spotColors[color];
       }

--- a/tests/unit/color.spec.js
+++ b/tests/unit/color.spec.js
@@ -27,6 +27,14 @@ describe('color', function () {
     ]);
   });
 
+  test('normalize named color case-insensitively', function () {
+    const doc = new PDFDocument();
+
+    expect(doc._normalizeColor('red')).toEqual([1, 0, 0]);
+    expect(doc._normalizeColor('Red')).toEqual([1, 0, 0]);
+    expect(doc._normalizeColor('RED')).toEqual([1, 0, 0]);
+  });
+
   test('normalize with spot color', function () {
     const doc = new PDFDocument();
     doc.addSpotColor('PANTONE 123 C', 0.1, 0.2, 0.3, 0.4);


### PR DESCRIPTION
## Problem

Fixes #1275.

`fillAndStroke("Red", "#900")` renders black instead of red, while
`fillAndStroke("red", "#900")` works. CSS named colors are defined as
case-insensitive keywords, but `_normalizeColor` in
`lib/mixins/color.js` looked up the `namedColors` table with the raw,
un-lowercased string. Since the table's keys are all lowercase, any
other casing ("Red", "RED", "DarkBlue", ...) silently missed the
lookup and fell through with no color applied.

## Fix

Lowercase the color string before indexing into `namedColors` in
`_normalizeColor`. Spot color lookups (`this.spotColors[color]`) are
left untouched — those names are caller-registered via
`addSpotColor`/`registerFont`-style APIs and are intentionally
case-sensitive.

## Test plan

- Added a unit test in `tests/unit/color.spec.js` asserting
  `_normalizeColor` resolves `"red"`, `"Red"`, and `"RED"` to the same
  RGB value.
- `npx vitest run tests/unit/color.spec.js` — 5/5 pass.
- `npx vitest run` (full suite) — same pass/fail counts as on
  `master` before this change (10 pre-existing, unrelated timeouts in
  `tests/visual/pdfmake/*`, confirmed present on a clean checkout too;
  all other 525 tests pass).