### PR TITLE
Fix doc.file() throwing when the same in-memory attachment is added twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Fix `doc.file()` throwing when the same in-memory attachment is embedded twice under one name, because the creation and modified dates the deduplication check compares are absent for sources that are not read from disk
+
 ### [v0.20.1] - 2026-08-23
 
 - Add a Node ESM build so `import 'pdfkit'` in Node resolves to the Node build (real file system, native zlib, Node streams, self-registering standard fonts) instead of the browser bundle

--- a/lib/mixins/attachments.js
+++ b/lib/mixins/attachments.js
@@ -119,8 +119,20 @@ function isEqual(a, b) {
     a.Subtype === b.Subtype &&
     a.Params.CheckSum.toString() === b.Params.CheckSum.toString() &&
     a.Params.Size === b.Params.Size &&
-    a.Params.CreationDate.getTime() === b.Params.CreationDate.getTime() &&
-    ((a.Params.ModDate === undefined && b.Params.ModDate === undefined) ||
-      a.Params.ModDate.getTime() === b.Params.ModDate.getTime())
+    isSameDate(a.Params.CreationDate, b.Params.CreationDate) &&
+    isSameDate(a.Params.ModDate, b.Params.ModDate)
   );
+}
+
+/**
+ * Compare two dates, either of which may be absent.
+ *
+ * An in-memory source carries no file system timestamps, so `CreationDate` and
+ * `ModDate` are only present when the file was read from disk or the caller
+ * passed `creationDate` / `modifiedDate`. Two absent dates describe the same
+ * metadata; an absent date never matches a present one.
+ */
+function isSameDate(a, b) {
+  if (a === undefined || b === undefined) return a === b;
+  return a.getTime() === b.getTime();
 }

--- a/tests/unit/attachments.spec.js
+++ b/tests/unit/attachments.spec.js
@@ -245,6 +245,90 @@ describe('file', () => {
     ]);
   });
 
+  test('attach the same file multiple times without dates', () => {
+    const docData = logData(document);
+
+    document.file(Buffer.from('example text'), { name: 'file1.txt' });
+    document.file(Buffer.from('example text'), { name: 'file1.txt' });
+    document.end();
+
+    const numFiles = docData.filter(
+      (str) =>
+        typeof str === 'string' && str.startsWith('<<\n/Type /EmbeddedFile\n'),
+    );
+
+    expect(numFiles.length).toEqual(1);
+
+    // both filespecs point at the single embedded file
+    expect(docData).toContainChunk([
+      `9 0 obj`,
+      `<<
+/Type /Filespec
+/AFRelationship /Unspecified
+/F (file1.txt)
+/EF <<
+/F 8 0 R
+>>
+/UF (file1.txt)
+>>`,
+    ]);
+
+    expect(docData).toContainChunk([
+      `10 0 obj`,
+      `<<
+/Type /Filespec
+/AFRelationship /Unspecified
+/F (file1.txt)
+/EF <<
+/F 8 0 R
+>>
+/UF (file1.txt)
+>>`,
+    ]);
+  });
+
+  test('attach the same file twice, only one with a creation date', () => {
+    const docData = logData(document);
+
+    document.file(Buffer.from('example text'), { name: 'file1.txt' });
+    document.file(Buffer.from('example text'), {
+      name: 'file1.txt',
+      creationDate: date,
+    });
+    document.end();
+
+    const numFiles = docData.filter(
+      (str) =>
+        typeof str === 'string' && str.startsWith('<<\n/Type /EmbeddedFile\n'),
+    );
+
+    // the metadata differs, so the reference is not reused
+    expect(numFiles.length).toEqual(2);
+  });
+
+  test('attach the same file twice, only one with a modified date', () => {
+    const docData = logData(document);
+
+    document.file(Buffer.from('example text'), {
+      name: 'file1.txt',
+      creationDate: date,
+    });
+    document.file(Buffer.from('example text'), {
+      name: 'file1.txt',
+      creationDate: date,
+      modifiedDate: date,
+    });
+    document.end();
+
+    const numFiles = docData.filter(
+      (str) =>
+        typeof str === 'string' && str.startsWith('<<\n/Type /EmbeddedFile\n'),
+    );
+
+    // the metadata differs, so the reference is not reused
+    expect(numFiles.length).toEqual(2);
+  });
+
   test('throws when the ref is missing', () => {
     expect(() =>
       document.addNamedEmbeddedFile('phantom.txt', undefined),


### PR DESCRIPTION
`doc.file()` reuses an existing reference when the same attachment is embedded
twice, comparing metadata in `isEqual()`. That comparison dereferenced
`Params.CreationDate` unguarded, and the `ModDate` comparison below it covered
only the case where both sides were absent — so an asymmetric absence threw
there as well.

`CreationDate` / `ModDate` are set only in the `fs.statSync(src)` branch, so a
source that is not read from disk — an `ArrayBuffer`, a `Uint8Array` or a data
URL — has neither:

```js
const buffer = Buffer.from('example text');
doc.file(buffer, { name: 'file.txt' });
doc.file(buffer, { name: 'file.txt' });
// TypeError: Cannot read properties of undefined (reading 'getTime')
```

### Where it came from

The unguarded `.getTime()` comparison arrived in #1544, which fixed a real bug —
the dates were being compared by identity, so two equal dates never matched.
`bcc64c2` later added a guard to the `ModDate` line for the case where both
sides are absent, which is why only `CreationDate` looks obviously unguarded
today.

### The fix

Both dates now go through one helper. Two absent dates match; an absent date
never matches a present one.

Asymmetric absence returning `false` is the correct answer rather than merely
the safe one: the dates are written into the EmbeddedFile stream dictionary, so
reusing the first reference would silently discard the `creationDate` the second
caller passed.

No non-throwing path changes result — the only behaviour that moves is the one
that previously threw.

### Tests

3 added, all 3 fail on master, at three distinct positions in `isEqual` (both
`CreationDate` operands and the `ModDate` one). They discriminate rather than
just proving "no throw": the dedup case asserts both filespecs point at the same
`/F` reference, and the two asymmetric cases assert that two separate streams are
emitted.

Unit suite 431/431.
