### PR TITLE
fix: resolve `#standard-fonts/*` to one file under every condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Fix bundlers and file tracers packing the ESM copies of the standard font metrics instead of the CommonJS ones the Node build actually loads, which left `Cannot find module` errors for every standard font at runtime, by resolving the internal `#standard-fonts/*` mapping to a single file under all conditions
 - Fix `doc.file()` throwing when the same in-memory attachment is embedded twice under one name, because the creation and modified dates the deduplication check compares are absent for sources that are not read from disk
 
 ### [v0.20.1] - 2026-08-23

--- a/package.json
+++ b/package.json
@@ -154,10 +154,7 @@
       "node": "./lib/stream/node.js",
       "default": "./lib/stream/browser.js"
     },
-    "#standard-fonts/*": {
-      "require": "./js/standard-fonts/*.cjs",
-      "default": "./js/standard-fonts/*.mjs"
-    }
+    "#standard-fonts/*": "./js/standard-fonts/*.cjs"
   },
   "engine": [
     "node >= v20.0.0"

--- a/tests/package-resolution.mjs
+++ b/tests/package-resolution.mjs
@@ -5,6 +5,7 @@ import PDFDocument, { LineWrapper, registerFile } from 'pdfkit';
 import { toBytes } from 'pdfkit/output';
 
 const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
 
 assert.equal(
   import.meta.resolve('pdfkit'),
@@ -39,6 +40,29 @@ assert.equal(
   ),
   false,
 );
+
+// The node ESM build reaches the standard fonts through createRequire, so the
+// require condition is the only one ever taken at runtime. Bundlers and file
+// tracers walk this same file as ESM and resolve `#standard-fonts/*` under the
+// import condition instead: if the two point at different files, the tracer packs
+// the modules that are never loaded, omits the ones that are, and the bundle
+// throws `Cannot find module` on the first document. Keep every standard font
+// resolving to the one file the runtime uses, under both conditions.
+const standardFonts = Object.keys(packageJson.exports)
+  .filter((entry) => entry.startsWith('./standard-fonts/'))
+  .map((entry) => entry.slice('./standard-fonts/'.length));
+
+assert.equal(standardFonts.length, 14);
+
+for (const font of standardFonts) {
+  const expected = new URL(`../js/standard-fonts/${font}.cjs`, import.meta.url)
+    .href;
+  assert.equal(import.meta.resolve(`#standard-fonts/${font}`), expected);
+  assert.equal(
+    require.resolve(`#standard-fonts/${font}`),
+    fileURLToPath(expected),
+  );
+}
 
 const fileDocument = new PDFDocument();
 const fileOutput = toBytes(fileDocument);


### PR DESCRIPTION
## Problem

`js/pdfkit.node.mjs` loads the standard font metrics lazily through `createRequire`:

```js
const require$1 = createRequire(import.meta.url);
const STANDARD_FONTS = {
  Courier: () => require$1('#standard-fonts/Courier'),
  ...
};
```

`package.json#imports` maps those specifiers two ways:

```json
"#standard-fonts/*": {
  "require": "./js/standard-fonts/*.cjs",
  "default": "./js/standard-fonts/*.mjs"
}
```

The calls are `require`, so at runtime Node and Bun load the `.cjs` files —
`tests/package-resolution.mjs` already asserts as much. But a bundler or file tracer
walks the *same file* as ESM and resolves the *same specifiers* under `default`,
landing on the `.mjs` twins. The two disagree, and for anything that packages a traced
dependency set, the tracer wins.

With [`@vercel/nft`](https://github.com/vercel/nft) — the tracer behind Vercel,
Nitro/Nuxt and `@vercel/ncc` — tracing an ESM entry that imports pdfkit collects all
14 `js/standard-fonts/*.mjs` and none of the `.cjs` files:

```js
import { nodeFileTrace } from '@vercel/nft'
// entry.mjs: `import PDFDocument from 'pdfkit'; export default PDFDocument`
const { fileList } = await nodeFileTrace(['entry.mjs'])
;[...fileList].filter(f => f.includes('standard-fonts'))
// → every *.mjs, no *.cjs
```

The build succeeds and the package looks complete in the output. Then the first
document throws:

```
Cannot find module '#standard-fonts/Helvetica' from '/app/.output/server/node_modules/pdfkit/js/pdfkit.node.mjs'
```

Reproducible by copying that traced file list into a directory with no ancestor
`node_modules` and constructing a `PDFDocument` — fails under both Node 23 and Bun 1.4.

## Fix

Nothing reachable at runtime takes the import condition here. The browser builds
register fonts through `registerStdFonts` and never reference `#standard-fonts`
(`grep -c standard-fonts js/pdfkit.browser.mjs` → 0); the only consumer is
`lib/document.node.js`, reached by `require` from both node builds. The `default`
branch is therefore unreachable and serves only to point resolvers at files pdfkit
never loads.

```json
"#standard-fonts/*": "./js/standard-fonts/*.cjs"
```

Runtime behaviour is unchanged — same files, still lazy, still one font at a time.
Tracers now resolve what Node resolves, and traced output gets slightly smaller
because the unused ESM twins are no longer dragged along.

The public `./standard-fonts/*` export is untouched: consumers importing a standard
font by name still get the ESM build, and rollup still emits both variants.

### Alternative

If the conditional mapping should stay, the other way out is to have the build emit
explicit relative specifiers (`require('./standard-fonts/Courier.cjs')`) in the node
ESM bundle — unambiguous to every analyser, no condition resolution involved. Happy
to redo it that way if you prefer; it is a rollup-config change rather than a manifest
one.

## Test

`tests/package-resolution.mjs` gains a check that both conditions agree, walking every
standard font in the `exports` map rather than a single hardcoded one. It fails on
`master` at the first font:

```
+ actual   - expected
+ '.../js/standard-fonts/Courier.mjs'
- '.../js/standard-fonts/Courier.cjs'
```

`yarn test:package`, `yarn test:unit` (432 passing), `yarn lint` and `yarn prettier`
are all green with the change.

## Context

Hit downstream on a Nuxt/Nitro app: receipt PDFs quietly stopped being attached to
payment emails (the generation error was caught and logged) and every other PDF route
500'd, while CI stayed green — nothing in a normal test run exercises the packaged
output. Same class as #1779, one level further down.
