### PR TITLE
Fix addNamedDestination writing the wrong number of parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Fix `doc.file()` throwing when the same in-memory attachment is embedded twice under one name, because the creation and modified dates the deduplication check compares are absent for sources that are not read from disk
+- Fix `doc.addNamedDestination()` writing a destination that carries more parameters than its type takes, and throwing `unsupported number: NaN` when the top of an `XYZ` destination was left off or passed as `undefined`. Parameters beyond the type's list are now dropped, and a short list is filled out with null for the types whose parameters may be null (`XYZ`, `FitH`, `FitV`, `FitBH` and `FitBV`)
 
 ### [v0.20.1] - 2026-08-23
 

--- a/docs/destinations.md
+++ b/docs/destinations.md
@@ -13,6 +13,9 @@ Examples of creating anchor:
     // Insert anchor to display a portion of the current page, 1/2 inch in from the top and left and zoomed 50%
     doc.addNamedDestination('LINK', 'XYZ', 36, 36, 50);
 
+    // Insert anchor 1/2 inch in from the top and left, leaving the zoom as the reader has it
+    doc.addNamedDestination('LINK', 'XYZ', 36, 36);
+
     // Insert anchor for this text
     doc.text('End of paragraph', { destination: 'ENDP' });
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -24,6 +24,20 @@ import TableMixin from './mixins/table';
 import MetadataMixin from './mixins/metadata';
 import { fromBinaryString } from './binary';
 
+// The parameters each destination type takes (ISO 32000-1, Table 151). `nullable`
+// marks the types whose parameters may each be null, which tells the reader to keep
+// that aspect of its current view. FitR has no such allowance.
+const DESTINATION_PARAMETERS = new Map([
+  ['XYZ', { count: 3, nullable: true }],
+  ['Fit', { count: 0, nullable: false }],
+  ['FitH', { count: 1, nullable: true }],
+  ['FitV', { count: 1, nullable: true }],
+  ['FitR', { count: 4, nullable: false }],
+  ['FitB', { count: 0, nullable: false }],
+  ['FitBH', { count: 1, nullable: true }],
+  ['FitBV', { count: 1, nullable: true }],
+]);
+
 class PDFDocument extends Readable {
   constructor(options = {}) {
     super(options);
@@ -221,9 +235,19 @@ class PDFDocument extends Readable {
 
   addNamedDestination(name, ...args) {
     if (args.length === 0) {
-      args = ['XYZ', null, null, null];
+      args = ['XYZ'];
     }
-    if (args[0] === 'XYZ' && args[2] !== null) {
+    const parameters = DESTINATION_PARAMETERS.get(args[0]);
+    if (parameters !== undefined) {
+      // Drop anything past the parameters the type takes, and fill out a short
+      // list only where a null parameter is allowed. The holes this leaves are
+      // written as null by PDFObject.convert.
+      const length = parameters.count + 1;
+      if (args.length > length || parameters.nullable) {
+        args.length = length;
+      }
+    }
+    if (args[0] === 'XYZ' && args[2] != null) {
       args[2] = this.page.height - args[2];
     }
     args.unshift(this.page.dictionary);

--- a/tests/unit/trailer.spec.js
+++ b/tests/unit/trailer.spec.js
@@ -75,4 +75,91 @@ describe('Document trailer', () => {
 >>`,
     ]);
   });
+
+  test('writes null for XYZ parameters left off, rather than a NaN top', () => {
+    const docData = logData(document);
+    document.addNamedDestination('LINK1', 'XYZ', 36);
+    document.end();
+
+    expect(docData).toContainChunk([
+      '2 0 obj',
+      `<<
+/Dests <<
+  /Names [
+    (LINK1) [7 0 R /XYZ 36 null null]
+]
+>>
+>>`,
+    ]);
+  });
+
+  test('fills out a short parameter list for the types that allow null', () => {
+    const docData = logData(document);
+    document.addNamedDestination('LINK1', 'XYZ', 36, 36);
+    document.addNamedDestination('LINK2', 'FitH');
+    document.addNamedDestination('LINK3', 'FitV');
+    document.addNamedDestination('LINK4', 'FitBH');
+    document.addNamedDestination('LINK5', 'FitBV');
+    document.end();
+
+    expect(docData).toContainChunk([
+      '2 0 obj',
+      `<<
+/Dests <<
+  /Limits [(LINK1) (LINK5)]
+  /Names [
+    (LINK1) [7 0 R /XYZ 36 756 null]
+    (LINK2) [7 0 R /FitH null]
+    (LINK3) [7 0 R /FitV null]
+    (LINK4) [7 0 R /FitBH null]
+    (LINK5) [7 0 R /FitBV null]
+]
+>>
+>>`,
+    ]);
+  });
+
+  test('drops parameters beyond the list a destination type takes', () => {
+    const docData = logData(document);
+    document.addNamedDestination('LINK1', 'Fit', 99);
+    document.addNamedDestination('LINK2', 'FitB', 99);
+    document.addNamedDestination('LINK3', 'XYZ', 1, 2, 3, 4);
+    document.addNamedDestination('LINK4', 'FitR', 1, 2, 3, 4, 5);
+    document.end();
+
+    expect(docData).toContainChunk([
+      '2 0 obj',
+      `<<
+/Dests <<
+  /Limits [(LINK1) (LINK4)]
+  /Names [
+    (LINK1) [7 0 R /Fit]
+    (LINK2) [7 0 R /FitB]
+    (LINK3) [7 0 R /XYZ 1 790 3]
+    (LINK4) [7 0 R /FitR 1 2 3 4]
+]
+>>
+>>`,
+    ]);
+  });
+
+  // FitR is the one type whose parameters may not be null, so a short one is left as it
+  // was given rather than filled out. It is still not a valid destination; resizing it is
+  // out of scope here.
+  test('leaves a short FitR destination as it was given', () => {
+    const docData = logData(document);
+    document.addNamedDestination('LINK1', 'FitR', 1, 2, 3);
+    document.end();
+
+    expect(docData).toContainChunk([
+      '2 0 obj',
+      `<<
+/Dests <<
+  /Names [
+    (LINK1) [7 0 R /FitR 1 2 3]
+]
+>>
+>>`,
+    ]);
+  });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix. No linked issue.

`addNamedDestination` passes its arguments straight through, so a call can write a
destination carrying more or fewer parameters than its type takes (ISO 32000-1,
Table 151). Two things go wrong.

**It can throw.** An `XYZ` top is flipped against the page height, and
`page.height - undefined` is `NaN`:

```js
doc.addNamedDestination('LINK', 'XYZ', 36);
doc.end();   // Error: unsupported number: NaN
```

That is raised from `PDFObject.number` at `doc.end()` and names neither the method
nor the argument. Only the top position was affected — an undefined `left` or `zoom`
already serialised as `null` — so the method was inconsistent about which missing
parameter it tolerated. Passing the top explicitly as `undefined` threw the same way
and no longer does, which is the one behaviour change an existing caller could
notice.

**Surplus parameters silently produce a dead link.** `pdfjs-dist` rejects these
outright, so `getDestination()` resolves to `null` and the link goes nowhere:

| call | before | after |
| --- | --- | --- |
| `addNamedDestination('L', 'Fit', 99)` | `[page /Fit 99]` — dead | `[page /Fit]` |
| `addNamedDestination('L', 'XYZ', 1, 2, 3, 4)` | `[page /XYZ 1 790 3 4]` — dead | `[page /XYZ 1 790 3]` |

Short parameter lists are the milder half, since a reader does accept
`[page /XYZ left top]`. But it is still a parameter short of what Table 151 defines,
and it is the natural way to write a contents entry meant to jump to a point without
disturbing the reader's zoom: `addNamedDestination('LINK', 'XYZ', x, y)`.

**What the change does.** Arguments are trimmed to the type's parameter list, and a
short list is filled out with `null` for the five types whose parameters Table 151
allows to be null: `XYZ`, `FitH`, `FitV`, `FitBH` and `FitBV`. **`FitR` has no such
allowance**, so a short `FitR` is passed through exactly as it is today, as is a
destination type that is not recognised. This resizes the argument list; it does not
validate the parameter values, so `('L', 'FitR', 1, null, 3, 4)` still goes out as it
does now.

Across all eight types at arities 0–5, every exact-arity output is byte-identical to
`master` — no well-formed call changes. `doc.text(..., { destination })` and the image
path both pass every parameter explicitly and are unaffected.

**One thing I left alone, and a question.**

`XYZ`'s top is flipped against the page height but `FitH`'s is not, so
`docs/destinations.md:11` describes `('LINK', 'FitH', 100)` as *"vertical top is
100"* while that value reaches the reader in bottom-left origin — unlike the `XYZ`
example below it on line 14. `tests/unit/trailer.spec.js` pins the current behaviour,
so I have not touched it and it is out of scope here. Is that deliberate? If you
would like it changed I am happy to do it separately.

**Checklist**:

- [x] Unit Tests
- [x] Documentation
- [x] Update CHANGELOG.md
- [x] Ready to be merged
