### PR TITLE
Fix doc.text() throwing NaN with lineBreak false and underline/strike/link/goTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix bundlers and file tracers packing the ESM copies of the standard font metrics instead of the CommonJS ones the Node build actually loads, which left `Cannot find module` errors for every standard font at runtime, by resolving the internal `#standard-fonts/*` mapping to a single file under all conditions
 - Fix `doc.file()` throwing when the same in-memory attachment is embedded twice under one name, because the creation and modified dates the deduplication check compares are absent for sources that are not read from disk
+- Fix `doc.text()` throwing `unsupported number: NaN` when `lineBreak: false` is combined with `underline`, `strike`, `link` or `goTo`, because the rendered width was computed from the line wrapper's measurements, which are never produced when wrapping is disabled
 
 ### [v0.20.1] - 2026-08-23
 

--- a/lib/mixins/text.js
+++ b/lib/mixins/text.js
@@ -524,9 +524,15 @@ export default {
     }
 
     // calculate the actual rendered width of the string after word and character spacing
+    // the wrapper supplies textWidth and wordCount; measure them directly when it did not run
+    const measuredWidth =
+      options.textWidth ??
+      this.widthOfString(text, options) - characterSpacing * (text.length - 1);
+    const measuredWordCount =
+      options.wordCount ?? (text.trim() ? text.trim().split(/\s+/).length : 0);
     const renderedWidth =
-      options.textWidth +
-      wordSpacing * (options.wordCount - 1) +
+      measuredWidth +
+      wordSpacing * (measuredWordCount - 1) +
       characterSpacing * (text.length - 1);
 
     // create link annotations if the link option is given

--- a/tests/unit/text.spec.js
+++ b/tests/unit/text.spec.js
@@ -201,6 +201,23 @@ Q
 
       expect(docData).toContainText({ text: 'text with null x' });
     });
+
+    test.each([
+      ['underline', { underline: true }],
+      ['strike', { strike: true }],
+      ['link', { link: 'http://example.com/' }],
+      ['goTo', { goTo: 'anchor' }],
+    ])('with lineBreak false and %s', (_name, extraOptions) => {
+      const docData = logData(document);
+
+      document.text('no line break', 50, 50, {
+        lineBreak: false,
+        ...extraOptions,
+      });
+      document.end();
+
+      expect(docData).toContainText({ text: 'no line break' });
+    });
   });
 
   describe('text with structure parent links', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix. Fixes #401.

`doc.text(str, x, y, { lineBreak: false, underline: true })` throws `Error: unsupported number: NaN`. The same happens with `strike`, `link` and `goTo` — anything that reaches `_fragment`'s rendered-width calculation.

The chain: `_initOptions` only assigns `result.width` when `result.lineBreak !== false` (`lib/mixins/text.js:421`), and `_text` only constructs a `LineWrapper` `if (options.width)` (`lib/mixins/text.js:82`). But `options.textWidth` and `options.wordCount` are written *only* inside the wrapper (`lib/line_wrapper.js:238-239`), so with `lineBreak: false` they stay `undefined` and

```js
const renderedWidth =
  options.textWidth + wordSpacing * (options.wordCount - 1) + characterSpacing * (text.length - 1);
```

evaluates to `NaN`. That reaches `lineTo()` and then `PDFObject.number`, whose range guard `n > -1e21 && n < 1e21` is false for `NaN`, so it throws (`lib/object.js:164-170`).

The 2015 report describes this as invisible text rather than a crash, because `number()` did not throw back then. The title understates what it does today.

**The fix** supplies only the two missing inputs, leaving the wrapper's formula alone. `_line` 80 lines up already handles the no-wrapper case this way — `this.x += this.widthOfString(text, options)` (`lib/mixins/text.js:449`) — as does `boundsOfString` in its non-wrapped branch (`lib/mixins/text.js:186`). So the library already knows how to measure an unwrapped fragment; `_fragment` was just missing the fallback.

The values are local consts and are never assigned back to `options`, so continued-text state and `_textOptions` inheritance are untouched. I grepped the other readers of that state before changing it — `line_wrapper.js:238-239` (the writer), `line_wrapper.js:356`, `text.js:178-179` (inside a wrapper callback) and `text.js:475` (guarded by `if (options.width)`) — none of them see a different value than before.

**Verification.** Built from `master` (`c6f57c6`) rather than testing the published package, since this area has moved recently.

Before the change, four public-API combinations throw and three controls pass:

```
FAIL  lineBreak:false + underline -> unsupported number: NaN
FAIL  lineBreak:false + strike    -> unsupported number: NaN
FAIL  lineBreak:false + link      -> unsupported number: NaN
FAIL  lineBreak:false + goTo      -> unsupported number: NaN
OK    underline alone / lineBreak:false alone / lineBreak:false + width + underline
```

After it, all seven pass. The four new cases in `tests/unit/text.spec.js` are verified red-green: with `lib/mixins/text.js` reverted and the tests kept, all four fail with `unsupported number: NaN`.

Full unit suite: 432 passing on unmodified `master`, 436 with this change — the delta is exactly the four new cases, with no existing test changing state. `yarn lint` is clean.

**Checklist**:

- [x] Unit Tests
- [x] Documentation — N/A, this is a crash fix with no public API or behaviour change for existing working input
- [x] Update CHANGELOG.md
- [x] Ready to be merged

Credit to @ashelley for the report.

Disclosure: I use AI assistance in my work, and I review and verify everything before it goes out. The runs above are my own.
