### PR TITLE
Document the parameter list each destination type takes

### DIFF
--- a/docs/destinations.md
+++ b/docs/destinations.md
@@ -16,6 +16,29 @@ Examples of creating anchor:
     // Insert anchor for this text
     doc.text('End of paragraph', { destination: 'ENDP' });
 
+Each destination type takes a fixed, positional parameter list:
+
+| type | parameters |
+| --- | --- |
+| `XYZ` | `left`, `top`, `zoom` |
+| `Fit` | none |
+| `FitH` | `top` |
+| `FitV` | `left` |
+| `FitR` | `left`, `bottom`, `right`, `top` |
+| `FitB` | none |
+| `FitBH` | `top` |
+| `FitBV` | `left` |
+
+`XYZ` is the only type whose vertical coordinate is converted: give its `top` measured
+from the top of the page, as everywhere else in PDFKit. The others are written through
+unchanged, so `FitH` and `FitBH`'s `top`, and `FitR`'s `bottom` and `top`, are measured
+from the bottom of the page.
+
+A destination carrying more parameters than its type takes is not valid; `FitR` must
+carry all four, and `XYZ` at least `left` and `top`. For `XYZ`, `FitH`, `FitV`, `FitBH`
+and `FitBV` a parameter may be `null`, which tells the reader to keep that aspect of its
+current view. Called with no type at all, `addNamedDestination(name)` writes `XYZ` with
+all three parameters `null`.
 
 Examples of go to link to anchor:
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation. This is the note you said yes to in #1783.

`docs/destinations.md` showed three worked calls but never stated the parameter lists, and
six of the eight destination types appear nowhere on the page — so for those there was
nothing to infer an arity from at all. The note adds the eight types from ISO 32000-1
Table 151 with their positional parameters, which of them accept `null`, and what the
zero-argument call produces.

It also names the one conversion the method performs, which is the part I think earns its
place: an `XYZ` top is flipped against the page height, while `FitH`, `FitBH` and `FitR`'s
vertical coordinates are written through unchanged. The page's own two examples already
disagree about the origin —

```
doc.addNamedDestination('LINK', 'FitH', 100);        // -> [page /FitH 100]
doc.addNamedDestination('LINK', 'XYZ', 36, 36, 50);  // -> [page /XYZ 36 756 50]
```

— and nothing said so, so a reader who carries the `XYZ` example's convention into a `FitH`
call lands at the wrong end of the page.

Every arity and the `null` rule were checked against the `pdfjs-dist` in this repo's dev
dependencies, and `FitR`'s parameter order against the way its viewer consumes them
(`x = destArray[2]`, `y = destArray[3]`, `width = destArray[4] - x`).

One thing worth flagging rather than leaving you to find: the table will render as literal
pipes, because the docs are built with `markdown@0.5.0` and the table dialect is not
enabled. `docs/getting_started.md` and `docs/outline.md` already ship that way through both
generators, so I matched the neighbours rather than making this page the odd one out — but
say the word and I'll convert it to a bullet list.

I'll close #1783 in favour of this.

**Checklist**:

- [ ] Unit Tests — n/a, documentation only
- [x] Documentation
- [ ] Update CHANGELOG.md — n/a, the `Unreleased` section carries behaviour changes
- [x] Ready to be merged
