### PR TITLE
Fix annotation rectangle under a rotated transformation matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Add a `hidden` option to form annotation methods, for a field that should start hidden (e.g. one an interactive action reveals later) instead of the usual default of visible and printable
+- Fix annotations placed under `doc.rotate()` marking the wrong area, because `_convertRect` derived each corner's y from the already transformed x and mapped only two of the four corners, so the rectangle a viewer makes interactive did not follow the rotated content. Fixes #1153
 
 ### [v0.20.2] - 2026-08-29
 

--- a/lib/mixins/annotations.js
+++ b/lib/mixins/annotations.js
@@ -180,19 +180,31 @@ export default {
 
   _convertRect(x1, y1, w, h) {
     // flip y1 and y2
-    let y2 = y1;
+    const y2 = y1;
     y1 += h;
 
     // make x2
-    let x2 = x1 + w;
+    const x2 = x1 + w;
 
     // apply current transformation matrix to points
     const [m0, m1, m2, m3, m4, m5] = this._ctm;
-    x1 = m0 * x1 + m2 * y1 + m4;
-    y1 = m1 * x1 + m3 * y1 + m5;
-    x2 = m0 * x2 + m2 * y2 + m4;
-    y2 = m1 * x2 + m3 * y2 + m5;
+    const transform = (x, y) => [m0 * x + m2 * y + m4, m1 * x + m3 * y + m5];
 
-    return [x1, y1, x2, y2];
+    // ISO 32000-1 12.5.2 defines Rect as an axis aligned rectangle in default
+    // user space, so a rotated or skewed matrix needs the bounding box of all
+    // four transformed corners. Two corners are enough only while the matrix
+    // keeps the axes aligned, and picking the extremes also keeps the result
+    // normalized ([llx lly urx ury], ISO 32000-1 7.9.5) when the matrix
+    // mirrors an axis.
+    const corners = [
+      transform(x1, y1),
+      transform(x2, y1),
+      transform(x2, y2),
+      transform(x1, y2),
+    ];
+    const xs = corners.map((corner) => corner[0]);
+    const ys = corners.map((corner) => corner[1]);
+
+    return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
   },
 };

--- a/lib/mixins/annotations.js
+++ b/lib/mixins/annotations.js
@@ -178,33 +178,29 @@ export default {
     return this.annotate(x, y, w, h, annotationOptions);
   },
 
-  _convertRect(x1, y1, w, h) {
-    // flip y1 and y2
-    const y2 = y1;
-    y1 += h;
-
-    // make x2
-    const x2 = x1 + w;
-
-    // apply current transformation matrix to points
+  _convertRect(x, y, w, h) {
+    // apply the current transformation matrix to the corner at (x, y) and to
+    // the two edge vectors that reach the other three corners from it
     const [m0, m1, m2, m3, m4, m5] = this._ctm;
-    const transform = (x, y) => [m0 * x + m2 * y + m4, m1 * x + m3 * y + m5];
+    const ox = m0 * x + m2 * y + m4;
+    const oy = m1 * x + m3 * y + m5;
+    const wx = m0 * w;
+    const wy = m1 * w;
+    const hx = m2 * h;
+    const hy = m3 * h;
 
     // ISO 32000-1 12.5.2 defines Rect as an axis aligned rectangle in default
-    // user space, so a rotated or skewed matrix needs the bounding box of all
-    // four transformed corners. Two corners are enough only while the matrix
-    // keeps the axes aligned, and picking the extremes also keeps the result
-    // normalized ([llx lly urx ury], ISO 32000-1 7.9.5) when the matrix
+    // user space, so under a rotated or skewed matrix it is the bounding box of
+    // all four corners rather than one opposing pair. Each corner is (ox, oy)
+    // plus either edge or both, so the low bound adds the negative part of each
+    // edge and the high bound the positive part. That also returns the
+    // normalized [llx lly urx ury] ISO 32000-1 7.9.5 asks for when the matrix
     // mirrors an axis.
-    const corners = [
-      transform(x1, y1),
-      transform(x2, y1),
-      transform(x2, y2),
-      transform(x1, y2),
+    return [
+      ox + (wx < 0 ? wx : 0) + (hx < 0 ? hx : 0),
+      oy + (wy < 0 ? wy : 0) + (hy < 0 ? hy : 0),
+      ox + (wx > 0 ? wx : 0) + (hx > 0 ? hx : 0),
+      oy + (wy > 0 ? wy : 0) + (hy > 0 ? hy : 0),
     ];
-    const xs = corners.map((corner) => corner[0]);
-    const ys = corners.map((corner) => corner[1]);
-
-    return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
   },
 };

--- a/tests/unit/annotations.spec.js
+++ b/tests/unit/annotations.spec.js
@@ -101,6 +101,28 @@ describe('Annotations', () => {
     });
   });
 
+  describe('rectangle under a transformation matrix', () => {
+    test('covers the whole rotated area', () => {
+      const docData = logData(document);
+
+      // Turning a 100x100 box a quarter turn about its own top left corner
+      // swings it from x 100..200 across to x 0..100 and leaves it spanning
+      // y 672..772 in default user space.
+      document.rotate(90, { origin: [100, 20] });
+      document.link(100, 20, 100, 100, 'http://www.example.com');
+
+      expect(docData.join('\n')).toContain('/Rect [0 672 100 772]');
+    });
+
+    test('leaves an untransformed rectangle alone', () => {
+      const docData = logData(document);
+
+      document.link(100, 20, 100, 100, 'http://www.example.com');
+
+      expect(docData.join('\n')).toContain('/Rect [100 672 200 772]');
+    });
+  });
+
   describe('undefined option values', () => {
     // `doc.annotate()` passes arbitrary dictionary keys straight through by
     // design, so unlike the acroform options there is no call site at which an


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix. Every annotation added while a rotated transformation matrix is in effect gets a rectangle that does not line up with the content it marks, so links added after `doc.rotate()` are clickable in the wrong place. Reported in #1153, which was closed without the code changing.

### The bug

`_convertRect` in `lib/mixins/annotations.js` assigns to `x1` on line 191 and then reads `x1` on line 192 to compute `y1`, so `y1` is derived from the already transformed x. Lines 193 and 194 do the same with `x2` and `y2`.

```js
x1 = m0 * x1 + m2 * y1 + m4;
y1 = m1 * x1 + m3 * y1 + m5;   // x1 is no longer the input x
x2 = m0 * x2 + m2 * y2 + m4;
y2 = m1 * x2 + m3 * y2 + m5;   // same for x2
```

`m1` is `_ctm[1]`, which is zero for the default page matrix, for `translate` and for `scale`. That zeroes the wrong term, which is why the defect stays hidden until something rotates or skews the matrix.

Only two of the four corners are mapped at all, which is the second half of the problem. `Rect` is an axis aligned rectangle in default user space (ISO 32000-1, 12.5.2), so once the matrix rotates the content, a single corner pair no longer bounds the rotated quadrilateral, and a matrix that mirrors an axis returns the pair in the wrong order for the `[llx lly urx ury]` form ISO 32000-1, 7.9.5 requires.

Reproduction, turning a 100 by 100 box a quarter turn about its own top left corner:

```js
const doc = new PDFDocument();
doc.rotate(90, { origin: [100, 20] });
doc.link(100, 20, 100, 100, 'http://www.example.com');
```

master writes `/Rect [0 872 100 772]`. The rotated box occupies x 0 to 100 and y 672 to 772, so the rectangle sits 200 points above the content and is inverted on top of that.

The gentler rotation from #1153, `doc.rotate(20, { origin: [150, 70] })` around the same box, produces `/Rect [85.914362 696.933948 214.085638 747.066052]`. The four transformed corners span x 85.914362 to 214.085638 and y 657.914362 to 786.085638, so the annotation ends up a 50 point tall band across the middle of a shape that is 128 points tall, and the top and bottom of the drawn box are not clickable. The width is right and the height is not, which is the scaled rather than rotated rectangle that issue describes.

### The fix

Map all four corners and return their bounding box.

Every matrix that keeps the axes aligned with both scale factors positive, which covers the default page matrix, `translate` and positive `scale`, yields the same two extremes the old code returned, so existing output does not move. A mirroring matrix now comes back normalized, and a rotated matrix comes back covering the rotated area.

`_markup` builds `QuadPoints` out of the same four numbers, so highlight, underline and strike are corrected with it, and their quadrilateral is now exactly the corners of `Rect` rather than a shape that can fall outside it, which is what ISO 32000-1, Table 179 asks for.

### Testing

Two tests added to `tests/unit/annotations.spec.js`. The first is the defect and fails on master:

```
AssertionError: expected '8 0 obj\n<<\n/S /URI\n/URI (http://ww…' to contain '/Rect [0 672 100 772]'
- /Rect [0 672 100 772]
+ /Rect [0 872 100 772]
```

The second pins the untransformed rectangle at `/Rect [100 672 200 772]` and passes both before and after, so a change that moved ordinary annotations would be caught.

`npx vitest run tests/unit/annotations.spec.js`: 16 passed, 16 total.

`npm test`: 60 test files passed, 493 tests passed, 0 failed, including `tests/visual`.

`npm run prettier`: "All matched files use Prettier code style!".

`npm run lint`: no output, no errors.

**Checklist**:

- [x] Unit Tests
- [ ] Documentation N/A
- [x] Update CHANGELOG.md
- [x] Ready to be merged
